### PR TITLE
Exclude Kotlin Android extensions from Wildcard import rule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/gihub/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -2,16 +2,19 @@ package com.gihub.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class NoWildcardImportsRule : Rule("no-wildcard-imports") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
             emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
-        if (node is LeafPsiElement && node.textMatches("*") && node.isPartOf(KtImportDirective::class)) {
-            emit(node.startOffset, "Wildcard import", false)
+        if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
+            val importDirective = node.psi as KtImportDirective
+            val path = importDirective.importPath?.pathStr
+            if (path != null && !path.startsWith("kotlinx.android.synthetic") && path.contains('*')) {
+                emit(node.startOffset, "Wildcard import", false)
+            }
         }
     }
-
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRuleTest.kt
@@ -15,10 +15,11 @@ class NoWildcardImportsRuleTest {
             import a.*
             import a.b.c.*
             import a.b
+            import kotlinx.android.synthetic.main.layout_name.*
             """.trimIndent()
         )).isEqualTo(listOf(
-            LintError(1, 10, "no-wildcard-imports", "Wildcard import"),
-            LintError(2, 14, "no-wildcard-imports", "Wildcard import")
+            LintError(1, 1, "no-wildcard-imports", "Wildcard import"),
+            LintError(2, 1, "no-wildcard-imports", "Wildcard import")
         ))
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                 <version>1.0.0</version>
                 <configuration>
                     <usage>
-                        # build "./ktlitn/target/ktlint" (executable jar)
+                        # build "./ktlint/target/ktlint" (executable jar)
                         ./mvnw -Pcapsule clean package -Dmaven.test.skip=true
 
                         # test (&amp; check code style)


### PR DESCRIPTION
According to codestyle, it allows to have wildcard imports for Kotlin Android Extensions:

```xml
<JetCodeStyleSettings>
    <option name="PACKAGES_TO_USE_STAR_IMPORTS">
      <value>
        <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
      </value>
    </option>
    <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
    <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
  </JetCodeStyleSettings>
```

This PR excludes imports of kotlin android extensions from being detected as 'Wildcard import'.

Plus, includes a fix for minor typo issue in pom.xml