### PR TITLE
Enable ModifierOrderRule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -7,6 +7,7 @@ class StandardRuleSetProvider : RuleSetProvider {
 
     override fun get(): RuleSet = RuleSet("standard",
         IndentationRule(),
+        ModifierOrderRule(),
         NoConsecutiveBlankLinesRule(),
         NoMultipleSpacesRule(),
         NoSemicolonsRule(),


### PR DESCRIPTION
ModifierOrderRule was added to release notes but not enabled, I think this was a mistake? This PR resolved the issue.

If this wasn't a mistake please close this PR.