### PR TITLE
Fix misleading indent lint error message

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -50,11 +50,11 @@ class IndentationRule : Rule("indent") {
                         if (node.isPartOf(KtParameterList::class) && firstParameterColumn.value != 0) {
                             if (firstParameterColumn.value - 1 != it.length) {
                                 emit(offset, "Unexpected indentation (${it.length}) (" +
-                                    "parameters should be either vertically aligned or indented by the multiple of 4" +
+                                    "parameters should be either vertically aligned or indented by the multiple of $indent" +
                                 ")", false)
                             }
                         } else {
-                            emit(offset, "Unexpected indentation (${it.length}) (it should be multiple of 4)", false)
+                            emit(offset, "Unexpected indentation (${it.length}) (it should be multiple of $indent)", false)
                         }
                     }
                     offset += it.length + 1

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -99,4 +99,18 @@ class IndentationRuleTest {
         )).isEmpty()
     }
 
+    @Test
+    fun testErrorWithCustomIndentSize() {
+        assertThat(IndentationRule().lint(
+            """
+            fun main() {
+               val v = ""
+                println(v)
+            }
+            """.trimIndent(),
+            mapOf("indent_size" to "3")
+        )).isEqualTo(listOf(
+            LintError(3, 1, "indent", "Unexpected indentation (4) (it should be multiple of 3)")
+        ))
+    }
 }


### PR DESCRIPTION
**Why**
The error message was hardcoded to 4 so read incorrectly when a custom indent size was used.