### PR TITLE
allow for named blocks

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -20,7 +20,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
             val spacingBefore: Boolean
             val spacingAfter: Boolean
             if (node.textMatches("{")) {
-                spacingBefore = prevLeaf is PsiWhiteSpace || (prevLeaf?.node?.elementType == KtTokens.LPAR &&
+                spacingBefore = prevLeaf is PsiWhiteSpace || prevLeaf is KtTokens.AT || (prevLeaf?.node?.elementType == KtTokens.LPAR &&
                     (node.parent is KtLambdaExpression || node.parent.parent is KtLambdaExpression))
                 spacingAfter = nextLeaf is PsiWhiteSpace || nextLeaf?.node?.elementType == KtTokens.RBRACE
             } else

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -20,7 +20,7 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
             val spacingBefore: Boolean
             val spacingAfter: Boolean
             if (node.textMatches("{")) {
-                spacingBefore = prevLeaf is PsiWhiteSpace || prevLeaf is KtTokens.AT || (prevLeaf?.node?.elementType == KtTokens.LPAR &&
+                spacingBefore = prevLeaf is PsiWhiteSpace || prevLeaf?.node?.elementType == KtTokens.AT || (prevLeaf?.node?.elementType == KtTokens.LPAR &&
                     (node.parent is KtLambdaExpression || node.parent.parent is KtLambdaExpression))
                 spacingAfter = nextLeaf is PsiWhiteSpace || nextLeaf?.node?.elementType == KtTokens.RBRACE
             } else

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRuleTest.kt
@@ -1,8 +1,8 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.LintError
-import com.github.shyiko.ktlint.test.lint
 import com.github.shyiko.ktlint.test.format
+import com.github.shyiko.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.Test
 
@@ -11,6 +11,7 @@ class SpacingAroundCurlyRuleTest {
     @Test
     fun testLint() {
         assertThat(SpacingAroundCurlyRule().lint("fun emit() { }")).isEmpty()
+        assertThat(SpacingAroundCurlyRule().lint("fun emit() { val a = a@{ } }")).isEmpty()
         assertThat(SpacingAroundCurlyRule().lint("fun emit() {}")).isEmpty()
         assertThat(SpacingAroundCurlyRule().lint("fun main() { val v = if (true){return 0} }"))
             .isEqualTo(listOf(


### PR DESCRIPTION
Kotlin supports named blocks in cases where you want to return early or return from an inner block without returning a function, the syntax is as so:

```kotlin
fun printNFromList(list: List<*>, count: Int) {
  list.mapIndexed a@{ item, index ->
    if (index > count) return@a
    println(item)
  }
}
printNFromList(listOf(1, 2, 3), 2)
```

obviously that's contrived because `return@map` would suffice as well, but our code sometimes requires operations like `.map { .map { } }` which means `return@method` doesn't work, named blocks are required.