### PR TITLE
Upgrade to kotlin 1.1.3-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: java
+jdk:
+  - oraclejdk8
 script: ./mvnw clean verify

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -1,5 +1,6 @@
 package com.github.shyiko.ktlint.core
 
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
@@ -37,7 +38,7 @@ object KtLint {
 
     init {
         val project = KotlinCoreEnvironment.createForProduction(Disposable {},
-            CompilerConfiguration(), emptyList()).project
+            CompilerConfiguration(), EnvironmentConfigFiles.EMPTY).project
         // everything below (up to PsiFileFactory.getInstance(...)) is to get AST mutations (`ktlint -F ...`) working
         // otherwise it's not needed
         val pomModel: PomModel = object : UserDataHolderBase(), PomModel {

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.1.0</kotlin.version>
+        <kotlin.version>1.1.3-2</kotlin.version>
         <aether.version>1.1.0</aether.version>
         <aether.maven.provider.version>3.2.5</aether.maven.provider.version>
         <args4j.version>2.33</args4j.version>


### PR DESCRIPTION
Using an older version of kotlin should not be an issue when using ktlint as a standalone tool. However when using the core engine embedded in a gradle plugin an upgrade is necessary to avoid a breaking change in `KotlinCoreEnvironment`. Reference:

https://github.com/jeremymailen/kotlinter-gradle/issues/13

Thanks!