### PR TITLE
Detect needless blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ It's also [easy to create your own](#creating-a-reporter).
 - No semicolons (unless used to separate multiple statements on the same line);
 - No wildcard / unused `import`s;
 - No consecutive blank lines;
+- No blank lines before `}`;
 - No trailing whitespaces;
 - No `Unit` returns (`fun fn {}` instead of `fun fn: Unit {}`);
 - No empty (`{}`) class bodies;
@@ -229,7 +230,7 @@ Go to `File -> Settings... -> Editor`
   - check `Optimize imports on the fly (for current project)`.
 - `Code Style -> Kotlin`
   - open `Imports` tab, select all `Use single name import` options and remove `import java.util.*` from `Packages to Use Import with '*'`.
-  - open `Blank Lines` tab, change `Keep Maximum Blank Lines` -> `In declarations` & `In code` to 1.
+  - open `Blank Lines` tab, change `Keep Maximum Blank Lines` -> `In declarations` & `In code` to 1 and `Before '}'` to 0.
   - (optional but recommended) open `Wrapping and Braces` tab, uncheck `Method declaration parameters -> Align when multiline`. 
   - (optional but recommended) open `Tabs and Indents` tab, change `Continuation indent` to 4.
 - `Inspections` 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -1,0 +1,26 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+
+class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
+    override fun visit(node: ASTNode, autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        if (node is PsiWhiteSpace) {
+            val split = node.getText().split("\n")
+
+            if (split.size > 2 && isNextElementRbrace(node)) {
+                emit(node.startOffset + split[0].length + split[1].length + 1,
+                    "Needless blank line(s)", true)
+                if (autoCorrect) {
+                    (node as LeafPsiElement).replaceWithText("${split.first()}\n${split.last()}")
+                }
+            }
+        }
+    }
+
+    private fun isNextElementRbrace(node: ASTNode) =
+        node.treeNext?.elementType?.index ?: 0 == 147.toShort()
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -12,6 +12,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),
+        NoBlankLineBeforeRbraceRule(),
         NoConsecutiveBlankLinesRule(),
         NoEmptyClassBodyRule(),
         // disabled until it's clear what to do in case of `import _.it`

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRuleTest.kt
@@ -1,0 +1,54 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.format
+import com.github.shyiko.ktlint.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.testng.annotations.Test
+
+class NoBlankLineBeforeRbraceRuleTest {
+    @Test
+    fun testLintInString() {
+        assertThat(NoBlankLineBeforeRbraceRule().lint(
+            "fun main() {println(\"\"\"\n\n\n}\"\"\")}")).isEmpty()
+    }
+
+    @Test
+    fun testLintBeforeRbrace() {
+        assertThat(NoBlankLineBeforeRbraceRule().lint(
+            """fun main() {
+                fun a() {
+
+                }
+                fun b()
+
+            }"""
+        )).isEqualTo(listOf(
+            LintError(3, 1, "no-blank-line-before-rbrace", "Needless blank line(s)"),
+            LintError(6, 1, "no-blank-line-before-rbrace", "Needless blank line(s)")
+        ))
+    }
+
+    @Test
+    fun testFormatBeforeRbrace() {
+        assertThat(NoBlankLineBeforeRbraceRule().format(
+            """
+            fun main() {
+                fun a() {
+
+                }
+                fun b()
+
+            }
+            """
+        )).isEqualTo(
+            """
+            fun main() {
+                fun a() {
+                }
+                fun b()
+            }
+            """
+        )
+    }
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRuleTest.kt
@@ -7,35 +7,90 @@ import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.Test
 
 class NoConsecutiveBlankLinesRuleTest {
-
     @Test
-    fun testLint() {
-        assertThat(NoConsecutiveBlankLinesRule().lint("fun main() {\n\n\n}")).isEqualTo(listOf(
-            LintError(3, 1, "no-consecutive-blank-lines", "Needless blank line(s)")
-        ))
-        assertThat(NoConsecutiveBlankLinesRule().lint("fun main() {println(\"\"\"\n\n\n\"\"\")}")).isEmpty()
+    fun testLintInDeclarations() {
+        assertThat(NoConsecutiveBlankLinesRule().lint(
+            """fun a() {
+
+            }
+
+
+            fun b() {
+
+            }"""
+        )).isEqualTo(listOf(
+            LintError(5, 1, "no-consecutive-blank-lines", "Needless blank line(s)")))
     }
 
     @Test
-    fun testFormat() {
+    fun testLintInCode() {
+        assertThat(NoConsecutiveBlankLinesRule().lint(
+            """fun main() {
+                fun a()
+                fun b()
+
+
+                fun c()
+            }"""
+        )).isEqualTo(listOf(
+            LintError(5, 1, "no-consecutive-blank-lines", "Needless blank line(s)")))
+    }
+
+    @Test
+    fun testLintInString() {
+        assertThat(NoConsecutiveBlankLinesRule().lint(
+            "fun main() {println(\"\"\"\n\n\n\"\"\")}")).isEmpty()
+    }
+
+    @Test
+    fun testFormatInDeclarations() {
         assertThat(NoConsecutiveBlankLinesRule().format(
             """
-            fun main() {
-
+            fun a() {
 
             }
 
 
+            fun b() {
 
+            }
             """
         )).isEqualTo(
             """
-            fun main() {
+            fun a() {
 
             }
 
+            fun b() {
+
+            }
             """
         )
     }
 
+    @Test
+    fun testFormatInCode() {
+        assertThat(NoConsecutiveBlankLinesRule().format(
+            """
+            fun main() {
+                fun a()
+                fun b()
+
+
+                fun c()
+
+            }
+            """
+        )).isEqualTo(
+            """
+            fun main() {
+                fun a()
+                fun b()
+
+                fun c()
+
+            }
+            """
+        )
+    }
 }


### PR DESCRIPTION
Closes #65 as IDEA's formatter is now able to detect blank lines before `}`. 

Please note that additionally to the case described in the issue 
```
fun main() {
    fun a() {
    }
    
}
``` 
The rule also prohibits the following construction: 
```
fun a() {

}
```
and formats it to 
```
fun a() {
}
```

