### PR TITLE
Update intellij idea integration with no blank line before rbrace rule

### DIFF
--- a/ktlint-intellij-idea-integration/src/main/resources/config/codestyles/ktlint.xml
+++ b/ktlint-intellij-idea-integration/src/main/resources/config/codestyles/ktlint.xml
@@ -11,6 +11,7 @@
   <codeStyleSettings language="kotlin">
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
As requested in #65 this PR update `ktlint-intellij-idea-integration` according to new added rule in #92.