### PR TITLE
Respect continuation indent size, make IndentationRule more intelligent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .gradle
 build
 !ktlint/src/main/resources/config/.idea
+/.idea
+*.iml

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -2,14 +2,26 @@ package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.KtLint
 import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.openapi.util.TextRange
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtSuperTypeList
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
@@ -22,16 +34,19 @@ class IndentationRule : Rule("indent") {
     }
 
     private var indent = DEFAULT_INDENT
+    private var continuationIndent = DEFAULT_INDENT
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
             val indentSize = editorConfig.get("indent_size")
+            val continuationIndentSize = editorConfig.get("continuation_indent_size")
             indent = indentSize?.toIntOrNull() ?: if (indentSize?.toLowerCase() == "unset") -1 else indent
+            continuationIndent = continuationIndentSize?.toIntOrNull() ?: if (continuationIndentSize?.toLowerCase() == "unset") -1 else indent
             return
         }
-        if (indent <= 0) {
+        if (indent <= 0 && continuationIndent <= 0) {
             return
         }
         if (node is PsiWhiteSpace && !node.isPartOf(PsiComment::class)) {
@@ -48,16 +63,21 @@ class IndentationRule : Rule("indent") {
                             TextRange(startOffset, startOffset)).column
                     } ?: 0
                 }
+                val parentElementIndent = calculatePreviousIndent(node)
+                val expectedIndentSize = calculateExpectedIndent(node)
                 lines.tail().forEach { line ->
-                    if (line.length % indent != 0) {
+                    if (line.isNotEmpty() && (line.length - parentElementIndent) % expectedIndentSize != 0) {
                         if (node.isPartOf(KtParameterList::class) && firstParameterColumn.value != 0) {
                             if (firstParameterColumn.value - 1 != line.length) {
                                 emit(offset, "Unexpected indentation (${line.length}) (" +
                                     "parameters should be either vertically aligned or indented by the multiple of $indent" +
-                                ")", false)
+                                    ")", false)
                             }
                         } else {
-                            emit(offset, "Unexpected indentation (${line.length}) (it should be multiple of $indent)", false)
+                            emit(offset,
+                                "Unexpected indentation (${line.length - parentElementIndent}) " +
+                                    "(it should be $expectedIndentSize)",
+                                false)
                         }
                     }
                     offset += line.length + 1
@@ -65,4 +85,64 @@ class IndentationRule : Rule("indent") {
             }
         }
     }
+
+    private fun calculateExpectedIndent(node: PsiWhiteSpace): Int =
+        if (continuationIndent == indent || shouldUseContinuationIndent(node)) continuationIndent else indent
+}
+
+private fun shouldUseContinuationIndent(node: PsiWhiteSpace): Boolean {
+    val parentNode = node.parent
+    val prevNode = findPrevSiblling(node)?.node?.elementType
+    val nextNode = node.nextSibling?.node?.elementType
+    return (
+        prevNode in KtTokens.ALL_ASSIGNMENTS
+            || parentNode is KtSecondaryConstructor
+            || nextNode == KtStubElementTypes.TYPE_REFERENCE
+            || node.nextSibling is KtSuperTypeList
+            || node.nextSibling is KtSuperTypeListEntry
+            || node.nextSibling is KtTypeProjection
+            || parentNode is KtValueArgumentList
+            || parentNode is KtBinaryExpression
+            || parentNode is KtDotQualifiedExpression
+            || parentNode is KtSafeQualifiedExpression
+            || parentNode is KtParenthesizedExpression
+        )
+}
+
+fun findPrevSiblling(node: PsiWhiteSpace): PsiElement? {
+    var prevNode = node.prevSibling
+    while (prevNode != null && (prevNode is PsiComment || prevNode is PsiWhiteSpace)) {
+        prevNode = prevNode.prevSibling
+    }
+    return prevNode
+}
+
+private fun calculatePreviousIndent(node: ASTNode): Int {
+    val parentNode = node.treeParent.psi
+    var prevIndent = 0
+    var prevSibling = parentNode
+    var prevSpaceIsFound = false
+    while (prevSibling != null && !prevSpaceIsFound) {
+        val nextNode = prevSibling.nextSibling?.node?.elementType
+        if (prevSibling is PsiWhiteSpace
+            && nextNode != KtStubElementTypes.TYPE_REFERENCE
+            && nextNode != KtStubElementTypes.SUPER_TYPE_LIST
+            && nextNode != KtNodeTypes.CONSTRUCTOR_DELEGATION_CALL) {
+            val prevLines = prevSibling.text.split("\n")
+            if (prevLines.size > 1) {
+                prevIndent = prevLines.last().length
+                prevSpaceIsFound = true
+            }
+        }
+        prevSibling = if (prevSpaceIsFound) {
+            null
+        } else {
+            if (prevSibling.prevSibling != null) {
+                prevSibling.prevSibling
+            } else {
+                prevSibling.parent
+            }
+        }
+    }
+    return prevIndent
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -33,7 +33,8 @@ class IndentationRuleTest {
             }
             """.trimIndent()
         )).isEqualTo(listOf(
-            LintError(12, 1, "indent", "Unexpected indentation (3) (it should be multiple of 4)")
+            LintError(12, 1, "indent", "Unexpected indentation (3) (it should be 4)"),
+            LintError(13, 1, "indent", "Unexpected indentation (5) (it should be 4)")
         ))
     }
 
@@ -73,7 +74,7 @@ class IndentationRuleTest {
             ) {}
             """.trimIndent()
         )).isEqualTo(listOf(
-            LintError(2, 1, "indent", "Unexpected indentation (3) (it should be multiple of 4)")
+            LintError(2, 1, "indent", "Unexpected indentation (3) (it should be 4)")
         ))
     }
 
@@ -110,7 +111,7 @@ class IndentationRuleTest {
             """.trimIndent(),
             mapOf("indent_size" to "3")
         )).isEqualTo(listOf(
-            LintError(3, 1, "indent", "Unexpected indentation (4) (it should be multiple of 3)")
+            LintError(3, 1, "indent", "Unexpected indentation (4) (it should be 3)")
         ))
     }
 
@@ -124,6 +125,371 @@ class IndentationRuleTest {
             }
             """.trimIndent(),
             mapOf("indent_size" to "unset")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testShouldRespectContinuationIndent() {
+        assertThat(IndentationRule().lint(
+            """
+                class TestContinuation {
+                    fun main() {
+                        val list = listOf(
+                              listOf(
+                                    "string",
+                                    "another string"
+                              ),
+                              listOf("one", "two")
+                        )
+                    }
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun `testUseContinuationIndentForConcatenation`() {
+        assertThat(IndentationRule().lint(
+            """
+                class TestSubClass {
+                    fun asdf(string: String) = string
+                    val c = asdf("long_string" +
+                          "")
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForDotQualifiedExpression() {
+        assertThat(IndentationRule().lint(
+            """
+                fun funA() {
+                    ClassA()
+                          .methodA()
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseIndentForObjectImplementation() {
+        assertThat(IndentationRule().lint(
+            """
+                @Test fun field() {
+                    field.validateWith()
+                          .handleWith(object : InterfaceA {
+                              override fun handleFailed(input: String, errors: List<String>) {
+                                  failedMessages.addAll(errors)
+                              }
+
+                              override fun handleSucceeded() {
+                                  succeededMessages.add("success")
+                              }
+                          })
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testComplexAssignmentQualifiedAccessAndFunctionBody() {
+        assertThat(IndentationRule().lint(
+            """
+            fun funA() =
+                  doStuff().use {
+                      while (it.moveToNext()) {
+                          doMore()
+                      }
+                  }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForArgumentList() {
+        assertThat(IndentationRule().lint(
+            """
+                fun funA() {
+                    val valueA =
+                          listOf(ClassA(),
+                                ClassB())
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentInsideParenthesis() {
+        assertThat(IndentationRule().lint(
+            """
+                fun funA() {
+                    val valA = ClassA(
+                          field = (
+                                ClassB(
+                                      fieldBOne = "one",
+                                      fieldBTwo = "two",
+                                      fieldBThree = 0
+                                ))
+                    )
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseIndentForCustomGetter() {
+        assertThat(IndentationRule().lint(
+            """
+                val storyBody: String
+                    get() = String.format(body, "")
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentAfterAssignment() {
+        assertThat(IndentationRule().lint(
+            """
+        val valueA =
+              "{\"title\"}"
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForSuperTypeList() {
+        assertThat(IndentationRule().lint(
+            """
+            class ClassA(fieldA: TypeA,
+                         fieldB: TypeB = DefaultB) :
+                  SuperClassA(fieldA, fieldB)
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseIndentForFunctionBody() {
+        assertThat(IndentationRule().lint(
+            """
+                fun funA() {
+                    val valueA = ClassA()
+                    valueA.doStuff()
+                    assertThat(valueA.getFieldB()).isEqualTo(100L)
+                }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentInsideSuperTypeList() {
+        assertThat(IndentationRule().lint(
+            """
+            class ClassA : ClassB(), InterfaceA,
+                  InterfaceB {
+            }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForTypeProjection() {
+        assertThat(IndentationRule().lint(
+            """
+            val variable: SuperTpe<TypeA,
+                  TypeB> = Implementation()
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test(enabled = false)
+        //not sure if it should use continuation indent or same as parameters
+    fun testCommentBetweenParameterListShouldUseSameIndent() {
+        assertThat(IndentationRule().lint(
+            """
+            data class MyClass(val a: String,
+                               val b: String,
+                  //comment between properties
+                               val c: String)
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForAssignment() {
+        assertThat(IndentationRule().lint(
+            """
+            fun funA() {
+                val (a, b, c) =
+                      anotherFun()
+            }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test()
+    fun testUseContinuationIndentForTypeCasting() {
+        assertThat(IndentationRule().lint(
+            """
+            fun funA() = funB() as
+                  TypeA
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForConstructorDelegation() {
+        assertThat(IndentationRule().lint(
+            """
+            class A : B() {
+                constructor(a: String) :
+                      this(a)
+            }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun shouldUseContinuationInsideSafeQualifiedExpression() {
+        assertThat(IndentationRule().lint(
+            """
+            val valueA = call()
+                  //comment
+                  ?.chainCallC { it.anotherCall() }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testUseContinuationIndentForTypeDeclaration() {
+        assertThat(IndentationRule().lint(
+            """
+            private fun funA(a: Int, b: String):
+                  MyTypeA {
+                return MyTypeA(a, b)
+            }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testIgnoreSuperTypeListWhenCalculatePreviousIndent() {
+        assertThat(IndentationRule().lint(
+            """
+            class ClassA(a: TypeA) :
+                  BasePresenter<View>() {
+
+                private lateinit var view: View
+            }
+              """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testIgnoreConstructorDelegationCallWhenCalculatingPreviousIntent() {
+        assertThat(IndentationRule().lint(
+            """
+                class MyClass{
+                    constructor(a: TypeA) :
+                          super(a) {
+                        init(a)
+                    }
+                }
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test(enabled = false)
+        //Not sure it should be supported. Recommended way can be to put each argument on separate line
+    fun testFuncIndent() {
+        assertThat(IndentationRule().lint(
+            """
+            fun funA(a: A, b: B) {
+                return funB(a,
+                      b, { (id) ->
+                    funC(id)
+                }
+                )
+            }
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testComplexValueArgumentUsage() {
+        assertThat(IndentationRule().lint(
+            """
+            fun data() = listOf(
+                  with(ClassA()) {
+                      arrayOf({ paramA: TypeA ->
+                          paramA.build()
+                      }, funB())
+                  },
+                  arrayOf({ paramA: TypeA -> paramA.build() },
+                        funB()
+                  )
+            )
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testIgnoreCommentWhenCalculateParentIndent() {
+        assertThat(IndentationRule().lint(
+            """
+            fun funA(argA: String) =
+                  // comment
+                  // comment
+                  call(argA)
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
         )).isEmpty()
     }
 }


### PR DESCRIPTION
closes #76 

### Motivation
In my project, indent size is 4, but continuation size is 6. It means, that condition `line.length % indent != 0` always fails.

### Implementation details
Rule now calculates indent size relatively to parent element and compares it to expected indent size. Rule knows several cases when continuation indent should be used. For sure, it's not a complete list of cases. These are emerged during testing on my code base and I expect to see more of them when other people start to use it.

### Configuration
Continuation indent size can be specified via `continuation_indent_size` from `.editorconfig`. By default, regular indent size is used.

### Backward compatibility
Due to the fact, that previous implementation was too permissive, I expected that current rule can find some new violation. But for well formatted code, it should return same result. Of course, for the cases when `continuation_indent_size % indent_size == 0`

### Performance
I haven't noticed any major performance impacts. I've tested it on codebase with approximately 1800 kt files. `0.12.1` takes ~16s and new version takes ~ 17s
Nevertheless, I think about current implementation as "first working approach". I'm pretty sure that it can be improved either by using existing "Utils" class, either my implementing more intelligent and fast parent indent size.


