### PR TITLE
Indention Rule: Parameters should be aligned vertically

### DIFF
--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
@@ -1,0 +1,23 @@
+package com.github.shyiko.ktlint.core
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+data class IndentationConfig(val regular: Int, val continuation: Int, val disabled: Boolean) {
+    companion object {
+        private const val DEFAULT_INDENT = 4
+        private const val DEFAULT_CONTINUATION_INDENT = 4
+        const val REGULAR_KEY = "indent_size"
+        const val CONTINUATION_KEY = "continuation_indent_size"
+        fun create(node: ASTNode): IndentationConfig {
+            //TODO this will be used when https://github.com/shyiko/ktlint/issues/120 is fixed
+            val android = node.getUserData(KtLint.ANDROID_USER_DATA_KEY)!!
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            val indentSize = editorConfig.get(REGULAR_KEY)
+            val continuationIndentSize = editorConfig.get(CONTINUATION_KEY)
+            val regular = indentSize?.toIntOrNull() ?: DEFAULT_INDENT
+            val continuation = continuationIndentSize?.toIntOrNull() ?: DEFAULT_CONTINUATION_INDENT
+            val disabled = indentSize?.toLowerCase() == "unset" || continuationIndentSize?.toLowerCase() == "unset"
+            return IndentationConfig(regular = regular, continuation = continuation, disabled = disabled)
+        }
+    }
+}

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
@@ -5,19 +5,27 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 data class IndentationConfig(val regular: Int, val continuation: Int, val disabled: Boolean) {
     companion object {
         private const val DEFAULT_INDENT = 4
-        private const val DEFAULT_CONTINUATION_INDENT = 4
+        private const val DEFAULT_ANDROID_CONTINUATION_INDENT = 8
         const val REGULAR_KEY = "indent_size"
         const val CONTINUATION_KEY = "continuation_indent_size"
+
         fun create(node: ASTNode): IndentationConfig {
-            //TODO this will be used when https://github.com/shyiko/ktlint/issues/120 is fixed
             val android = node.getUserData(KtLint.ANDROID_USER_DATA_KEY)!!
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
             val indentSize = editorConfig.get(REGULAR_KEY)
             val continuationIndentSize = editorConfig.get(CONTINUATION_KEY)
             val regular = indentSize?.toIntOrNull() ?: DEFAULT_INDENT
-            val continuation = continuationIndentSize?.toIntOrNull() ?: DEFAULT_CONTINUATION_INDENT
+            val continuation = continuationIndentSize?.toIntOrNull() ?: defaultContinuationIndent(android)
             val disabled = indentSize?.toLowerCase() == "unset" || continuationIndentSize?.toLowerCase() == "unset"
             return IndentationConfig(regular = regular, continuation = continuation, disabled = disabled)
+        }
+
+        private fun defaultContinuationIndent(isAndroid: Boolean): Int {
+            return if (isAndroid) {
+                DEFAULT_ANDROID_CONTINUATION_INDENT
+            } else {
+                DEFAULT_INDENT
+            }
         }
     }
 }

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -233,7 +233,7 @@ object KtLint {
         format(text, ruleSets, emptyMap<String, String>(), cb, script = false)
 
     fun format(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
+               cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
 
     /**
      * Fix style violations.
@@ -249,7 +249,7 @@ object KtLint {
         format(text, ruleSets, emptyMap(), cb, script = true)
 
     fun formatScript(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
+                     cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
 
     private fun format(
         text: String,

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -232,8 +232,11 @@ object KtLint {
     fun format(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError, corrected: Boolean) -> Unit): String =
         format(text, ruleSets, emptyMap<String, String>(), cb, script = false)
 
-    fun format(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-               cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
+    fun format(
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
 
     /**
      * Fix style violations.
@@ -248,8 +251,11 @@ object KtLint {
     fun formatScript(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError, corrected: Boolean) -> Unit): String =
         format(text, ruleSets, emptyMap(), cb, script = true)
 
-    fun formatScript(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-                     cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
+    fun formatScript(
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
 
     private fun format(
         text: String,

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
@@ -27,7 +27,7 @@ abstract class Rule(val id: String) {
      * @param emit a way for rule to notify about a violation (lint error)
      */
     abstract fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
 
     object Modifier {
         /**

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
@@ -26,8 +26,10 @@ abstract class Rule(val id: String) {
      * @param autoCorrect indicates whether rule should attempt auto-correction
      * @param emit a way for rule to notify about a violation (lint error)
      */
-    abstract fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
+    abstract fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
 
     object Modifier {
         /**

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
@@ -13,8 +13,10 @@ class ErrorSuppressionTest {
     @Test
     fun testErrorSuppression() {
         class NoWildcardImportsRule : Rule("no-wildcard-imports") {
-            override fun visit(node: ASTNode, autoCorrect: Boolean,
-                               emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+            override fun visit(
+                node: ASTNode,
+                autoCorrect: Boolean,
+                emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
                 if (node is LeafPsiElement && node.textMatches("*") &&
                         PsiTreeUtil.getNonStrictParentOfType(node, KtImportDirective::class.java) != null) {
                     emit(node.startOffset, "Wildcard import", false)

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
@@ -14,7 +14,7 @@ class ErrorSuppressionTest {
     fun testErrorSuppression() {
         class NoWildcardImportsRule : Rule("no-wildcard-imports") {
             override fun visit(node: ASTNode, autoCorrect: Boolean,
-                    emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+                               emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
                 if (node is LeafPsiElement && node.textMatches("*") &&
                         PsiTreeUtil.getNonStrictParentOfType(node, KtImportDirective::class.java) != null) {
                     emit(node.startOffset, "Wildcard import", false)

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
@@ -1,0 +1,56 @@
+package com.github.shyiko.ktlint.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.FileElement
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+class IndentationConfigTest {
+    private val regularKey = IndentationConfig.REGULAR_KEY
+    private val continuationKey = IndentationConfig.CONTINUATION_KEY
+    private val expectedDefaultRegularIndent = 4
+    private val expectedDefaultContinuationIndent = 4
+    private lateinit var node: ASTNode
+
+    @BeforeMethod
+    fun setUp() {
+        node = FileElement(KtStubElementTypes.USER_TYPE, "")
+    }
+
+    @Test
+    fun shouldUseDefaultValues() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(expectedDefaultRegularIndent, expectedDefaultContinuationIndent, false))
+    }
+
+    @Test
+    fun shouldReadValuesFromConfig() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "1", continuationKey to "2")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(1, 2, false))
+    }
+
+    @Test
+    fun shouldBeDisabledWhenRegularUnset() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "unset", continuationKey to "2")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(expectedDefaultRegularIndent, 2, true))
+    }
+
+    @Test
+    fun shouldBeDisabledWhenContinuationUnset() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "1", continuationKey to "unset")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(1, expectedDefaultContinuationIndent, true))
+    }
+}

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
@@ -28,6 +28,14 @@ class IndentationConfigTest {
     }
 
     @Test
+    fun shouldReturnAndroidSpecificDefaultValues() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, true)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(4, 8, false))
+    }
+
+    @Test
     fun shouldReadValuesFromConfig() {
         node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
         node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
@@ -11,8 +11,10 @@ class KtLintTest {
     fun testRuleExecutionOrder() {
         open class R(private val bus: MutableList<String>, id: String) : Rule(id) {
             private var done = false
-            override fun visit(node: ASTNode, autoCorrect: Boolean,
-                               emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+            override fun visit(
+                node: ASTNode,
+                autoCorrect: Boolean,
+                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
                 if (node.elementType == KtStubElementTypes.FILE) {
                     bus.add("file:$id")
                 } else if (!done) {

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
@@ -12,7 +12,7 @@ class KtLintTest {
         open class R(private val bus: MutableList<String>, id: String) : Rule(id) {
             private var done = false
             override fun visit(node: ASTNode, autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                               emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
                 if (node.elementType == KtStubElementTypes.FILE) {
                     bus.add("file:$id")
                 } else

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -21,7 +21,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     private val noSpaceAroundTokens = TokenSet.create(DOT, SAFE_ACCESS)
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -20,8 +20,10 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     private val nextLineTokens = TokenSet.create(DOT, SAFE_ACCESS, ELVIS)
     private val noSpaceAroundTokens = TokenSet.create(DOT, SAFE_ACCESS)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -69,9 +69,7 @@ class IndentationRule : Rule("indent") {
                         && firstParameter.value?.node != node.nextSibling.node) {
                         if ((line.length + 1) != firstParameterColumn.value) {
                             emit(offset, "Unexpected indentation (${line.length}) (" +
-                                "parameters should be either vertically aligned or " +
-                                "indented by the multiple of $indent" +
-                                ")", true)
+                                "parameters should be vertically aligned)", true)
                         }
                     } else if (line.isNotEmpty() && (line.length - previousIndent) % expectedIndentSize != 0) {
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -2,7 +2,6 @@ package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.IndentationConfig
 import com.github.shyiko.ktlint.core.Rule
-import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -25,12 +24,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComme
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class IndentationRule : Rule("indent") {
-
-    companion object {
-        // indentation size recommended by JetBrains
-        private const val DEFAULT_INDENT = 4
-        private const val DEFAULT_CONTINUATION_INDENT = 8
-    }
 
     private var indentConfig = IndentationConfig(-1, -1, true)
 
@@ -116,35 +109,5 @@ class IndentationRule : Rule("indent") {
                 || parentNode is KtSafeQualifiedExpression
                 || parentNode is KtParenthesizedExpression
             )
-    }
-
-    private fun calculatePreviousIndent(node: ASTNode): Int {
-        val parentNode = node.treeParent?.psi
-        var prevIndent = 0
-        var prevSibling = parentNode
-        var prevSpaceIsFound = false
-        while (prevSibling != null && !prevSpaceIsFound) {
-            val nextNode = prevSibling.nextSibling?.node?.elementType
-            if (prevSibling is PsiWhiteSpace
-                && nextNode != KtStubElementTypes.TYPE_REFERENCE
-                && nextNode != KtStubElementTypes.SUPER_TYPE_LIST
-                && nextNode != KtNodeTypes.CONSTRUCTOR_DELEGATION_CALL) {
-                val prevLines = prevSibling.text.split('\n')
-                if (prevLines.size > 1) {
-                    prevIndent = prevLines.last().length
-                    prevSpaceIsFound = true
-                }
-            }
-            prevSibling = if (prevSpaceIsFound) {
-                null
-            } else {
-                if (prevSibling.prevSibling != null) {
-                    prevSibling.prevSibling
-                } else {
-                    prevSibling.parent
-                }
-            }
-        }
-        return prevIndent
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -34,9 +34,10 @@ class IndentationRule : Rule("indent") {
 
     private var indentConfig = IndentationConfig(-1, -1, true)
 
-
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             indentConfig = IndentationConfig.create(node)
             return

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
             PsiTreeUtil.nextLeaf(node, true)?.node?.elementType == KtTokens.RBRACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -9,8 +9,10 @@ import org.jetbrains.kotlin.lexer.KtTokens
 
 class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
             PsiTreeUtil.nextLeaf(node, true)?.node?.elementType == KtTokens.RBRACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val split = node.getText().split("\n")
             if (split.size > 3 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val split = node.getText().split("\n")
             if (split.size > 3 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -47,8 +47,10 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
             }
         }
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             fileNode = node
         } else if (node is PsiWhiteSpace && !node.textContains('\n') && node.getTextLength() > 1) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -48,7 +48,7 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
         }
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             fileNode = node
         } else

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 class NoSemicolonsRule : Rule("no-semi") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
                 !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -10,8 +10,10 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 
 class NoSemicolonsRule : Rule("no-semi") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
                 !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
             if (lines.size > 1) {
@@ -28,7 +28,7 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     }
 
     private fun checkForTrailingSpaces(lines: List<String>, offset: Int,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         var violationOffset = offset
         return lines.forEach { line ->
             if (!line.isEmpty()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
             if (lines.size > 1) {
@@ -26,8 +28,10 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
         }
     }
 
-    private fun checkForTrailingSpaces(lines: List<String>, offset: Int,
-                                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    private fun checkForTrailingSpaces(
+        lines: List<String>,
+        offset: Int,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         var violationOffset = offset
         return lines.forEach { line ->
             if (!line.isEmpty()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -42,7 +42,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private var packageName = ""
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
             ref.add("*")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -41,8 +41,10 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private val ref = mutableSetOf<String>()
     private var packageName = ""
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
             ref.add("*")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 class NoWildcardImportsRule : Rule("no-wildcard-imports") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -7,8 +7,10 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class NoWildcardImportsRule : Rule("no-wildcard-imports") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
@@ -1,0 +1,65 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.IndentationConfig
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeUtil
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
+    private var indentConfig = IndentationConfig(-1, -1, true)
+    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        if (node.elementType == KtStubElementTypes.FILE) {
+            indentConfig = IndentationConfig.create(node)
+            return
+        }
+        val previousIndent: Int by lazy { node.calculatePreviousIndent() }
+        val parentParameterList = node.treeParent
+        if (parentParameterList?.elementType == KtStubElementTypes.VALUE_PARAMETER_LIST
+            //do not enforce lambda parameters
+            && parentParameterList.treeParent?.elementType != KtNodeTypes.FUNCTION_LITERAL) {
+            val parentFile = TreeUtil.findParent(node, KtStubElementTypes.FILE)
+            if (parentFile != null
+                && node.elementType == KtStubElementTypes.VALUE_PARAMETER
+                && parentParameterList.textRange.substring(parentFile.text).contains("\n")
+                && node is CompositeElement) {
+                if (node.treePrev !is PsiWhiteSpace) {
+                    emit(node.startOffset, MISSED_NEW_LINE_ERROR, true)
+                    if (autoCorrect) {
+                        (parentParameterList as CompositeElement).addLeaf(
+                            KtTokens.WHITE_SPACE,
+                            "\n" + " ".repeat(previousIndent + indentConfig.regular),
+                            node)
+                    }
+                } else {
+                    val prevText = node.treePrev.text
+                    if (!prevText.startsWith("\n")) {
+                        emit(node.startOffset, MISSED_NEW_LINE_ERROR, true)
+                        if (autoCorrect) {
+                            (node.treePrev as LeafPsiElement)
+                                .rawReplaceWithText("\n" + " ".repeat(previousIndent + indentConfig.regular))
+                        }
+                    } else if (prevText.length - previousIndent - 1 != indentConfig.regular) {
+                        emit(node.startOffset,
+                            "Unexpected indentation for parameter ${prevText.length - previousIndent - 1} (should be ${indentConfig.regular})",
+                            true)
+                        if (autoCorrect) {
+                            (node.treePrev as LeafPsiElement)
+                                .rawReplaceWithText("\n" + " ".repeat(previousIndent + indentConfig.regular))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val RULE_ID = "parameters-on-separate-lines"
+        private const val MISSED_NEW_LINE_ERROR = "Parameter should be on separate line with indentation"
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -14,8 +14,10 @@ import org.jetbrains.kotlin.psi.KtTypeParameterList
 
 class SpacingAroundColonRule : Rule("colon-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString()) {
             if (node.isPartOf(KtAnnotation::class) || node.isPartOf(KtAnnotationEntry::class)) {
                 // todo: enfore "no spacing"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameterList
 class SpacingAroundColonRule : Rule("colon-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString()) {
             if (node.isPartOf(KtAnnotation::class) || node.isPartOf(KtAnnotationEntry::class)) {
                 // todo: enfore "no spacing"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -9,8 +9,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class SpacingAroundCommaRule : Rule("comma-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString() &&
             PsiTreeUtil.nextLeaf(node) !is PsiWhiteSpace) {
             emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class SpacingAroundCommaRule : Rule("comma-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString() &&
             PsiTreeUtil.nextLeaf(node) !is PsiWhiteSpace) {
             emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -29,8 +29,10 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
 
     private val keywordsWithoutSpaces = TokenSet.create(KtTokens.GET_KEYWORD, KtTokens.SET_KEYWORD)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
 
         if (node is LeafPsiElement) {
             if (tokenSet.contains(node.elementType) && node.nextLeaf() !is PsiWhiteSpace) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -45,7 +45,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
         EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW)
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -44,8 +44,10 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
     private val tokenSet = TokenSet.create(MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
         EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtTokens.RANGE) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node.psi, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node.psi, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.lexer.KtTokens
 
 class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtTokens.RANGE) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node.psi, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node.psi, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -11,6 +11,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         // disabled until it's clear how to reconcile difference in Intellij & Android Studio import layout
         // ImportOrderingRule(),
         NoLineBreakAfterElseRule(),
+        ParametersOnSeparateLinesRule(),
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/package.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/package.kt
@@ -1,8 +1,12 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import kotlin.reflect.KClass
 
 internal fun PsiElement.isPartOf(clazz: KClass<out PsiElement>) = getNonStrictParentOfType(clazz.java) != null
@@ -10,3 +14,33 @@ internal fun PsiElement.isPartOfString() = isPartOf(KtStringTemplateEntry::class
 
 internal fun <T> List<T>.head() = this.subList(0, this.size - 1)
 internal fun <T> List<T>.tail() = this.subList(1, this.size)
+
+internal fun ASTNode.calculatePreviousIndent(): Int {
+    val parentNode = this.treeParent?.psi
+    var prevIndent = 0
+    var prevSibling = parentNode
+    var prevSpaceIsFound = false
+    while (prevSibling != null && !prevSpaceIsFound) {
+        val nextNode = prevSibling.nextSibling?.node?.elementType
+        if (prevSibling is PsiWhiteSpace
+            && nextNode != KtStubElementTypes.TYPE_REFERENCE
+            && nextNode != KtStubElementTypes.SUPER_TYPE_LIST
+            && nextNode != KtNodeTypes.CONSTRUCTOR_DELEGATION_CALL) {
+            val prevLines = prevSibling.text.split('\n')
+            if (prevLines.size > 1) {
+                prevIndent = prevLines.last().length
+                prevSpaceIsFound = true
+            }
+        }
+        prevSibling = if (prevSpaceIsFound) {
+            null
+        } else {
+            if (prevSibling.prevSibling != null) {
+                prevSibling.prevSibling
+            } else {
+                prevSibling.parent
+            }
+        }
+    }
+    return prevIndent
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -140,7 +140,8 @@ class IndentationRuleTest {
             """.trimIndent(),
             script = true
         )).isEqualTo(listOf(
-            LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)")
+            LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)"),
+            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be either vertically aligned or indented by the multiple of 4)")
         ))
     }
 
@@ -503,6 +504,22 @@ class IndentationRuleTest {
                   // comment
                   // comment
                   call(argA)
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testLambdaParametersShouldBeAligned() {
+        assertThat(IndentationRule().lint(
+            """
+            val fieldExample =
+                  LongNameClass { paramA,
+                                  paramB,
+                                  paramC ->
+                      ClassB(paramA, paramB, paramC)
+                  }
             """.trimIndent(),
             mapOf("indent_size" to "4",
                 "continuation_indent_size" to "6")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -141,7 +141,7 @@ class IndentationRuleTest {
             script = true
         )).isEqualTo(listOf(
             LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)"),
-            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be either vertically aligned or indented by the multiple of 4)")
+            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be vertically aligned)")
         ))
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
@@ -1,0 +1,151 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.format
+import com.github.shyiko.ktlint.test.lint
+import org.assertj.core.api.Assertions
+import org.testng.annotations.Test
+
+class ParametersOnSeparateLinesRuleTest {
+    private val expectedErrorMessage = "Parameter should be on separate line with indentation"
+    private val configUserData = mapOf("indent_size" to "4", "continuation_indent_size" to "6")
+    private fun expectedIndentErrorMessage(actualInden: Int, expectedIndent: Int): String {
+        return "Unexpected indentation for parameter $actualInden (should be $expectedIndent)"
+    }
+
+    @Test
+    fun testClassWithAbsentLineBreak() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(paramA: String, paramB: String,
+                         paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(1, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(1, 30, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(2, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(13, 4)))
+        )
+    }
+
+    @Test
+    fun testFormatClassWithAbsentLineBreak() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+            """
+            class ClassA(paramA: String, paramB: String,
+                         paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            class ClassA(
+                paramA: String,
+                paramB: String,
+                paramC: String)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testValidClassDefinitionWithMultipleLines() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(
+                paramA: String,
+                paramB: String,
+                paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testValidClassDefinitionOnOneLine() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(paramA: String, paramB: String, paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testErrorWhenFirstParameterIsNotOnNewLine() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            fun f(a: Any,
+                  b: Any,
+                  c: Any) {
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(1, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(2, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4)),
+                LintError(3, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4))
+            )
+        )
+    }
+
+    @Test
+    fun testLambdaParameters() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            val fieldExample =
+                  LongNameClass { paramA,
+                                  paramB,
+                                  paramC ->
+                      ClassB(paramA, paramB, paramC)
+                  }
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testFailWhenWrongIndentIsUsed() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class A {
+                fun f(
+                   a: Any,
+                   b: Any) {
+                }
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(3, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4)),
+                LintError(4, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4))
+            )
+        )
+    }
+
+    @Test
+    fun testRespectOuterIndent() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+            """
+            class A {
+                fun f(a: Any,
+                      b: Any,
+                      c: Any) {
+                }
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            class A {
+                fun f(
+                    a: Any,
+                    b: Any,
+                    c: Any) {
+                }
+            }
+            """.trimIndent()
+        )
+    }
+}

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 class NoVarRule : Rule("no-var") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches("var") &&
                 getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
             emit(node.startOffset, "Unexpected var, use val instead", false)

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 
 class NoVarRule : Rule("no-var") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches("var") &&
                 getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
             emit(node.startOffset, "Unexpected var, use val instead", false)

--- a/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
+++ b/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
@@ -23,7 +23,7 @@ class DumpAST @JvmOverloads constructor(
     private var lastNode: ASTNode? = null
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             lineNumberColumnLength = (location(PsiTreeUtil.getDeepestLast(node.psi).node)?.line ?: 0)
                 .let { var v = it; var c = 0; while (v > 0) { c++; v /= 10 }; c }

--- a/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
+++ b/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
@@ -22,8 +22,10 @@ class DumpAST @JvmOverloads constructor(
     private var lineNumberColumnLength: Int = 0
     private var lastNode: ASTNode? = null
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             lineNumberColumnLength = (location(PsiTreeUtil.getDeepestLast(node.psi).node)?.line ?: 0)
                 .let { var v = it; var c = 0; while (v > 0) { c++; v /= 10 }; c }

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -583,12 +583,12 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         }
 
     private fun lint(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError) -> Unit) =
+                     cb: (e: LintError) -> Unit) =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.lint(text, ruleSets, userData, cb) else
             KtLint.lintScript(text, ruleSets, userData, cb)
 
     private fun format(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError, corrected: Boolean) -> Unit): String =
+                       cb: (e: LintError, corrected: Boolean) -> Unit): String =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.format(text, ruleSets, userData, cb) else
             KtLint.formatScript(text, ruleSets, userData, cb)
 
@@ -599,7 +599,7 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
     }
 
     private fun <T> Sequence<Callable<T>>.parallel(cb: (T) -> Unit,
-        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
+                                                   numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
         val q = ArrayBlockingQueue<Future<T>>(numberOfThreads)
         val pill = object : Future<T> {
 

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -580,12 +580,20 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
             map
         }
 
-    private fun lint(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError) -> Unit) =
+    private fun lint(
+        fileName: String,
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError) -> Unit) =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.lint(text, ruleSets, userData, cb) else KtLint.lintScript(text, ruleSets, userData, cb)
 
-    private fun format(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError, corrected: Boolean) -> Unit): String =
+    private fun format(
+        fileName: String,
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.format(text, ruleSets, userData, cb) else KtLint.formatScript(text, ruleSets, userData, cb)
 
     private fun java.net.URLClassLoader.addURLs(url: Iterable<java.net.URL>) {
@@ -594,8 +602,9 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         url.forEach { method.invoke(this, it) }
     }
 
-    private fun <T> Sequence<Callable<T>>.parallel(cb: (T) -> Unit,
-                                                   numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
+    private fun <T> Sequence<Callable<T>>.parallel(
+        cb: (T) -> Unit,
+        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
         val q = ArrayBlockingQueue<Future<T>>(numberOfThreads)
         val pill = object : Future<T> {
 

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
@@ -22,8 +22,10 @@ import org.eclipse.aether.transport.http.HttpTransporterFactory
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.io.File
 
-class MavenDependencyResolver(baseDir: File, val repositories: Iterable<RemoteRepository>,
-                              forceUpdate: Boolean) {
+class MavenDependencyResolver(
+    baseDir: File,
+    val repositories: Iterable<RemoteRepository>,
+    forceUpdate: Boolean) {
 
     private val repoSystem: RepositorySystem
     private val session: RepositorySystemSession

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
@@ -23,7 +23,7 @@ import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.io.File
 
 class MavenDependencyResolver(baseDir: File, val repositories: Iterable<RemoteRepository>,
-    forceUpdate: Boolean) {
+                              forceUpdate: Boolean) {
 
     private val repoSystem: RepositorySystem
     private val session: RepositorySystemSession


### PR DESCRIPTION
Enforce that parameters should be aligned. This is how default IntelliJ
formatter works. This approach is listed on:
https://ktlint.github.io/#rule-indentation
https://kotlinlang.org/docs/reference/coding-conventions.html#class-header-formatting
https://android.github.io/kotlin-guides/style.html#functions

This allows to prevent stuff like that
```kotlin
class ClassA(paramA: String
    paramB: String,
        paramC: String)
```


@shyiko Sorry, initially I was fully confident that "align parameters"  is how rule is designed (https://ktlint.github.io/#rule-indentation). But just before creating PR, I've noticed that error message actually allow not aligned parameters.
>Unexpected indentation (${line.length}) (parameters should be either vertically aligned **or indented by the multiple** of $indent)

Feel free to close this PR, if you actually want to preserve that option.