### PR TITLE
Use JVM_CONFIG_FILES instead of EMPTY

### DIFF
--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -49,7 +49,7 @@ object KtLint {
         }
         DiagnosticLogger.setFactory(LoggerFactory::class.java)
         val project = KotlinCoreEnvironment.createForProduction(Disposable {},
-            CompilerConfiguration(), EnvironmentConfigFiles.EMPTY).project
+            CompilerConfiguration(), EnvironmentConfigFiles.JVM_CONFIG_FILES).project
         // everything below (up to PsiFileFactory.getInstance(...)) is to get AST mutations (`ktlint -F ...`) working
         // otherwise it's not needed
         val pomModel: PomModel = object : UserDataHolderBase(), PomModel {


### PR DESCRIPTION
Because `EnvironmentConfigFiles.EMPTY` is removed in 1.2.20
This is copy-paste of the similar change from Kotlin itself
https://github.com/JetBrains/kotlin/commit/afc9d3ef8b5bd4f2db44823f4eb62c3ce7d5dfd1#diff-0326941c85afd979faa6998b7b95bff8R55

fixes #131

Commit message from kotlin repository says
>Drop EnvironmentConfigFiles.EMPTY and replace its only usage in
preprocessor with JVM_CONFIG_FILES: it's easier and won't affect
anything

Unfortunately, I have no idea if the same reasoning applies to KtLint or not. My feeling says yes, because `KtLint` and `Preprocessor` classes look very very similar.