### PR TITLE
Revert "Changed continuation_indent_size to 4"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ ktlint recognizes the following [.editorconfig](http://editorconfig.org/) proper
 # possible values: number (e.g. 2), "unset" (makes ktlint ignore indentation completely)  
 indent_size=4
 # possible values: number (e.g. 2), "unset"
+# it's automatically set to 8 on `ktlint --android ...` (per Android Kotlin Style Guide)
 continuation_indent_size=unset
 # true (recommended) / false
 insert_final_newline=unset
@@ -264,6 +265,7 @@ Go to `File -> Settings... -> Editor`
     - uncheck `Method declaration parameters -> Align when multiline`. 
   - (optional but recommended) open `Tabs and Indents` tab
     - change `Continuation indent` to 4   
+    (to be compliant with [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html) value should stay equal 8).
 - `Inspections` 
   - change `Severity` level of `Unused import directive`, `Redundant semicolon` and (optional but recommended) `Unused symbol` to `ERROR`.
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -30,6 +30,8 @@ class IndentationRule : Rule("indent") {
         // indentation size recommended by JetBrains
         private const val DEFAULT_INDENT = 4
         private const val DEFAULT_CONTINUATION_INDENT = 4
+        // Android Kotlin Style Guide
+        private const val DEFAULT_CONTINUATION_INDENT_ANDROID = 8
     }
 
     private var indent = -1
@@ -43,7 +45,8 @@ class IndentationRule : Rule("indent") {
             val indentSize = editorConfig.get("indent_size")
             val continuationIndentSize = editorConfig.get("continuation_indent_size")
             indent = indentSize?.toIntOrNull() ?: if (indentSize?.toLowerCase() == "unset") -1 else DEFAULT_INDENT
-            continuationIndent = continuationIndentSize?.toIntOrNull() ?: DEFAULT_CONTINUATION_INDENT
+            continuationIndent = continuationIndentSize?.toIntOrNull()
+                ?: if (android) DEFAULT_CONTINUATION_INDENT_ANDROID else DEFAULT_CONTINUATION_INDENT
             return
         }
         if (indent <= 0 || continuationIndent <= 0) {

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/IntellijIDEAIntegration.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/IntellijIDEAIntegration.kt
@@ -27,7 +27,7 @@ object IntellijIDEAIntegration {
         }
         val home = System.getProperty("user.home")
         val editorConfig: Map<String, String> = EditorConfig.of(".") ?: emptyMap()
-        val continuationIndentSize = editorConfig["continuation_indent_size"]?.toIntOrNull() ?: 4
+        val continuationIndentSize = editorConfig["continuation_indent_size"]?.toIntOrNull() ?: if (android) 8 else 4
         val indentSize = editorConfig["indent_size"]?.toIntOrNull() ?: 4
         val codeStyleName = "ktlint${
             if (continuationIndentSize == 4) "" else "-cis$continuationIndentSize"


### PR DESCRIPTION
This reverts commit ed261175241807e0f7bb0428db8f2d0c253f6e5e.

As per discussion from the GitHub issue [1], the default continuation
indent for Android should be 8 rather than 4. This matches the Android
Kotlin style guide.

[1] https://github.com/shyiko/ktlint/issues/120