### PR TITLE
Class and function header format rules, autocorrection for IndentionRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ max_line_length=off
 > Skip all the way to the "Integration" section if you don't plan to use `ktlint`'s command line interface.
 
 ```sh
-curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.13.0/ktlint &&
+curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.14.0/ktlint &&
   chmod a+x ktlint &&
   sudo mv ktlint /usr/local/bin/
 ```
@@ -164,7 +164,7 @@ $ ktlint --install-git-pre-commit-hook
         <dependency>
             <groupId>com.github.shyiko</groupId>
             <artifactId>ktlint</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.0</version>
         </dependency>
         <!-- additional 3rd party ruleset(s) can be specified here -->
     </dependencies>
@@ -193,7 +193,7 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.github.shyiko:ktlint:0.13.0"
+    ktlint "com.github.shyiko:ktlint:0.14.0"
     // additional 3rd party ruleset(s) can be specified here
     // just add them to the classpath (e.g. ktlint 'groupId:artifactId:version') and 
     // ktlint will pick them up
@@ -298,7 +298,7 @@ A complete sample project (with tests and build files) is included in this repo 
 #### AST
 
 While writing/debugging [Rule](ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt)s it's often helpful to have an AST
-printed out to see the structure rules have to work with. ktlint >= 0.13.0 has `--print-ast` flag specifically for this purpose
+printed out to see the structure rules have to work with. ktlint >= 0.14.0 has `--print-ast` flag specifically for this purpose
 (usage: `ktlint --color --print-ast <file>`).  
 An example of the output it shown below. 
 

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
@@ -1,0 +1,23 @@
+package com.github.shyiko.ktlint.core
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+data class IndentationConfig(val regular: Int, val continuation: Int, val disabled: Boolean) {
+    companion object {
+        private const val DEFAULT_INDENT = 4
+        private const val DEFAULT_CONTINUATION_INDENT = 4
+        const val REGULAR_KEY = "indent_size"
+        const val CONTINUATION_KEY = "continuation_indent_size"
+        fun create(node: ASTNode): IndentationConfig {
+            //TODO this will be used when https://github.com/shyiko/ktlint/issues/120 is fixed
+            val android = node.getUserData(KtLint.ANDROID_USER_DATA_KEY)!!
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            val indentSize = editorConfig.get(REGULAR_KEY)
+            val continuationIndentSize = editorConfig.get(CONTINUATION_KEY)
+            val regular = indentSize?.toIntOrNull() ?: DEFAULT_INDENT
+            val continuation = continuationIndentSize?.toIntOrNull() ?: DEFAULT_CONTINUATION_INDENT
+            val disabled = indentSize?.toLowerCase() == "unset" || continuationIndentSize?.toLowerCase() == "unset"
+            return IndentationConfig(regular = regular, continuation = continuation, disabled = disabled)
+        }
+    }
+}

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/IndentationConfig.kt
@@ -5,19 +5,27 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 data class IndentationConfig(val regular: Int, val continuation: Int, val disabled: Boolean) {
     companion object {
         private const val DEFAULT_INDENT = 4
-        private const val DEFAULT_CONTINUATION_INDENT = 4
+        private const val DEFAULT_ANDROID_CONTINUATION_INDENT = 8
         const val REGULAR_KEY = "indent_size"
         const val CONTINUATION_KEY = "continuation_indent_size"
+
         fun create(node: ASTNode): IndentationConfig {
-            //TODO this will be used when https://github.com/shyiko/ktlint/issues/120 is fixed
             val android = node.getUserData(KtLint.ANDROID_USER_DATA_KEY)!!
             val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
             val indentSize = editorConfig.get(REGULAR_KEY)
             val continuationIndentSize = editorConfig.get(CONTINUATION_KEY)
             val regular = indentSize?.toIntOrNull() ?: DEFAULT_INDENT
-            val continuation = continuationIndentSize?.toIntOrNull() ?: DEFAULT_CONTINUATION_INDENT
+            val continuation = continuationIndentSize?.toIntOrNull() ?: defaultContinuationIndent(android)
             val disabled = indentSize?.toLowerCase() == "unset" || continuationIndentSize?.toLowerCase() == "unset"
             return IndentationConfig(regular = regular, continuation = continuation, disabled = disabled)
+        }
+
+        private fun defaultContinuationIndent(isAndroid: Boolean): Int {
+            return if (isAndroid) {
+                DEFAULT_ANDROID_CONTINUATION_INDENT
+            } else {
+                DEFAULT_INDENT
+            }
         }
     }
 }

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -233,7 +233,7 @@ object KtLint {
         format(text, ruleSets, emptyMap<String, String>(), cb, script = false)
 
     fun format(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
+               cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
 
     /**
      * Fix style violations.
@@ -249,7 +249,7 @@ object KtLint {
         format(text, ruleSets, emptyMap(), cb, script = true)
 
     fun formatScript(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
+                     cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
 
     private fun format(
         text: String,

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -232,8 +232,11 @@ object KtLint {
     fun format(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError, corrected: Boolean) -> Unit): String =
         format(text, ruleSets, emptyMap<String, String>(), cb, script = false)
 
-    fun format(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-               cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
+    fun format(
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
 
     /**
      * Fix style violations.
@@ -248,8 +251,11 @@ object KtLint {
     fun formatScript(text: String, ruleSets: Iterable<RuleSet>, cb: (e: LintError, corrected: Boolean) -> Unit): String =
         format(text, ruleSets, emptyMap(), cb, script = true)
 
-    fun formatScript(text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-                     cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
+    fun formatScript(
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
 
     private fun format(
         text: String,

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/KtLint.kt
@@ -236,7 +236,8 @@ object KtLint {
         text: String,
         ruleSets: Iterable<RuleSet>,
         userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = false)
+        cb: (e: LintError, corrected: Boolean) -> Unit
+    ): String = format(text, ruleSets, userData, cb, script = false)
 
     /**
      * Fix style violations.
@@ -255,7 +256,8 @@ object KtLint {
         text: String,
         ruleSets: Iterable<RuleSet>,
         userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String = format(text, ruleSets, userData, cb, script = true)
+        cb: (e: LintError, corrected: Boolean) -> Unit
+    ): String = format(text, ruleSets, userData, cb, script = true)
 
     private fun format(
         text: String,

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfig.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 data class MaxLineLengthConfig(val lineLength: Int) {
 
     fun isDisabled(): Boolean = lineLength <= 0
+    fun isEnabled(): Boolean = !isDisabled()
 
     companion object {
         private const val DEFAULT_ANDROID_MAX_LINE_SIZE = 100

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfig.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfig.kt
@@ -1,0 +1,28 @@
+package com.github.shyiko.ktlint.core
+
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+data class MaxLineLengthConfig(val lineLength: Int) {
+
+    fun isDisabled(): Boolean = lineLength <= 0
+
+    companion object {
+        private const val DEFAULT_ANDROID_MAX_LINE_SIZE = 100
+        private const val DEFAULT_MAX_LINE_SIZE = 0
+        private const val KEY_MAX_LINE_LENGTH = "max_line_length"
+        fun create(node: ASTNode): MaxLineLengthConfig {
+            val android = node.getUserData(KtLint.ANDROID_USER_DATA_KEY)!!
+            val editorConfig = node.getUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY)!!
+            val maxLineLength = editorConfig.get(KEY_MAX_LINE_LENGTH)?.toIntOrNull() ?: defaultLineSize(android)
+            return MaxLineLengthConfig(maxLineLength)
+        }
+
+        private fun defaultLineSize(isAndroid: Boolean): Int {
+            return if (isAndroid) {
+                DEFAULT_ANDROID_MAX_LINE_SIZE
+            } else {
+                DEFAULT_MAX_LINE_SIZE
+            }
+        }
+    }
+}

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
@@ -27,7 +27,7 @@ abstract class Rule(val id: String) {
      * @param emit a way for rule to notify about a violation (lint error)
      */
     abstract fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
 
     object Modifier {
         /**

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
@@ -26,8 +26,10 @@ abstract class Rule(val id: String) {
      * @param autoCorrect indicates whether rule should attempt auto-correction
      * @param emit a way for rule to notify about a violation (lint error)
      */
-    abstract fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
+    abstract fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
 
     object Modifier {
         /**

--- a/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
+++ b/ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt
@@ -29,7 +29,8 @@ abstract class Rule(val id: String) {
     abstract fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit)
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    )
 
     object Modifier {
         /**

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
@@ -16,7 +16,8 @@ class ErrorSuppressionTest {
             override fun visit(
                 node: ASTNode,
                 autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+                emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit
+            ) {
                 if (node is LeafPsiElement && node.textMatches("*") &&
                         PsiTreeUtil.getNonStrictParentOfType(node, KtImportDirective::class.java) != null) {
                     emit(node.startOffset, "Wildcard import", false)

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
@@ -13,8 +13,10 @@ class ErrorSuppressionTest {
     @Test
     fun testErrorSuppression() {
         class NoWildcardImportsRule : Rule("no-wildcard-imports") {
-            override fun visit(node: ASTNode, autoCorrect: Boolean,
-                               emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+            override fun visit(
+                node: ASTNode,
+                autoCorrect: Boolean,
+                emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
                 if (node is LeafPsiElement && node.textMatches("*") &&
                         PsiTreeUtil.getNonStrictParentOfType(node, KtImportDirective::class.java) != null) {
                     emit(node.startOffset, "Wildcard import", false)

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/ErrorSuppressionTest.kt
@@ -14,7 +14,7 @@ class ErrorSuppressionTest {
     fun testErrorSuppression() {
         class NoWildcardImportsRule : Rule("no-wildcard-imports") {
             override fun visit(node: ASTNode, autoCorrect: Boolean,
-                    emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+                               emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
                 if (node is LeafPsiElement && node.textMatches("*") &&
                         PsiTreeUtil.getNonStrictParentOfType(node, KtImportDirective::class.java) != null) {
                     emit(node.startOffset, "Wildcard import", false)

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
@@ -1,0 +1,56 @@
+package com.github.shyiko.ktlint.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.FileElement
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+class IndentationConfigTest {
+    private val regularKey = IndentationConfig.REGULAR_KEY
+    private val continuationKey = IndentationConfig.CONTINUATION_KEY
+    private val expectedDefaultRegularIndent = 4
+    private val expectedDefaultContinuationIndent = 4
+    private lateinit var node: ASTNode
+
+    @BeforeMethod
+    fun setUp() {
+        node = FileElement(KtStubElementTypes.USER_TYPE, "")
+    }
+
+    @Test
+    fun shouldUseDefaultValues() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(expectedDefaultRegularIndent, expectedDefaultContinuationIndent, false))
+    }
+
+    @Test
+    fun shouldReadValuesFromConfig() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "1", continuationKey to "2")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(1, 2, false))
+    }
+
+    @Test
+    fun shouldBeDisabledWhenRegularUnset() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "unset", continuationKey to "2")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(expectedDefaultRegularIndent, 2, true))
+    }
+
+    @Test
+    fun shouldBeDisabledWhenContinuationUnset() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,
+            EditorConfig.fromMap(mapOf(regularKey to "1", continuationKey to "unset")))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(1, expectedDefaultContinuationIndent, true))
+    }
+}

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/IndentationConfigTest.kt
@@ -28,6 +28,14 @@ class IndentationConfigTest {
     }
 
     @Test
+    fun shouldReturnAndroidSpecificDefaultValues() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, true)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = IndentationConfig.create(node)
+        assertThat(config).isEqualTo(IndentationConfig(4, 8, false))
+    }
+
+    @Test
     fun shouldReadValuesFromConfig() {
         node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
         node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY,

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
@@ -11,8 +11,10 @@ class KtLintTest {
     fun testRuleExecutionOrder() {
         open class R(private val bus: MutableList<String>, id: String) : Rule(id) {
             private var done = false
-            override fun visit(node: ASTNode, autoCorrect: Boolean,
-                               emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+            override fun visit(
+                node: ASTNode,
+                autoCorrect: Boolean,
+                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
                 if (node.elementType == KtStubElementTypes.FILE) {
                     bus.add("file:$id")
                 } else if (!done) {

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
@@ -14,7 +14,8 @@ class KtLintTest {
             override fun visit(
                 node: ASTNode,
                 autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+            ) {
                 if (node.elementType == KtStubElementTypes.FILE) {
                     bus.add("file:$id")
                 } else if (!done) {

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/KtLintTest.kt
@@ -12,7 +12,7 @@ class KtLintTest {
         open class R(private val bus: MutableList<String>, id: String) : Rule(id) {
             private var done = false
             override fun visit(node: ASTNode, autoCorrect: Boolean,
-                emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                               emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
                 if (node.elementType == KtStubElementTypes.FILE) {
                     bus.add("file:$id")
                 } else

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfigTest.kt
@@ -39,4 +39,25 @@ class MaxLineLengthConfigTest {
         val config = MaxLineLengthConfig.create(node)
         assertThat(config.lineLength).isEqualTo(100)
     }
+
+    @Test
+    fun shouldBeDisabledWhenNegativeValue() {
+        val config = MaxLineLengthConfig(-1)
+        assertThat(config.isDisabled()).isTrue()
+        assertThat(config.isEnabled()).isFalse()
+    }
+
+    @Test
+    fun shouldBeDisabledWhenZeroValue() {
+        val config = MaxLineLengthConfig(0)
+        assertThat(config.isDisabled()).isTrue()
+        assertThat(config.isEnabled()).isFalse()
+    }
+
+    @Test
+    fun shouldBeEnabledWhenPositiveValue() {
+        val config = MaxLineLengthConfig(1)
+        assertThat(config.isDisabled()).isFalse()
+        assertThat(config.isEnabled()).isTrue()
+    }
 }

--- a/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfigTest.kt
+++ b/ktlint-core/src/test/kotlin/com/github/shyiko/ktlint/core/MaxLineLengthConfigTest.kt
@@ -1,0 +1,42 @@
+package com.github.shyiko.ktlint.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.FileElement
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+class MaxLineLengthConfigTest {
+    private lateinit var node: ASTNode
+    private val KEY = "max_line_length"
+
+    @BeforeMethod
+    fun setUp() {
+        node = FileElement(KtStubElementTypes.USER_TYPE, "")
+    }
+
+    @Test
+    fun shouldUseProvidedValue() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(mapOf(KEY to "120")))
+        val config = MaxLineLengthConfig.create(node)
+        assertThat(config.lineLength).isEqualTo(120)
+    }
+
+    @Test
+    fun shouldUseDefaultValue() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, false)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = MaxLineLengthConfig.create(node)
+        assertThat(config.lineLength).isEqualTo(0)
+    }
+
+    @Test
+    fun shouldUseAndroidDefaultValue() {
+        node.putUserData(KtLint.ANDROID_USER_DATA_KEY, true)
+        node.putUserData(KtLint.EDITOR_CONFIG_USER_DATA_KEY, EditorConfig.fromMap(emptyMap()))
+        val config = MaxLineLengthConfig.create(node)
+        assertThat(config.lineLength).isEqualTo(100)
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -21,7 +21,7 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     private val noSpaceAroundTokens = TokenSet.create(DOT, SAFE_ACCESS)
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -23,7 +23,8 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ChainWrappingRule.kt
@@ -20,8 +20,10 @@ class ChainWrappingRule : Rule("chain-wrapping") {
     private val nextLineTokens = TokenSet.create(DOT, SAFE_ACCESS, ELVIS)
     private val noSpaceAroundTokens = TokenSet.create(DOT, SAFE_ACCESS)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         /*
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement (DOT) | "."
            org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl (WHITE_SPACE) | "\n        "

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
@@ -96,16 +96,15 @@ class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
     }
 
     private fun shouldWrap(parentFile: ASTNode?, parentParameterList: ASTNode): Boolean {
-
         return parentFile != null &&
             //line break already present in parameter list
             (parentParameterList.textRange.substring(parentFile.text).contains("\n") ||
                 //entire class definition exceed max line length
                 (lineLengthConfig.isEnabled() &&
-                    classLengthWithoutBody(parentParameterList, parentFile) > lineLengthConfig.lineLength))
+                    headerBodyLength(parentParameterList, parentFile) > lineLengthConfig.lineLength))
     }
 
-    private fun classLengthWithoutBody(node: ASTNode, parentFile: ASTNode?): Int {
+    private fun headerBodyLength(node: ASTNode, parentFile: ASTNode?): Int {
         val parentNode = PsiTreeUtil.findFirstParent(
             node.psi,
             { psiElement ->
@@ -117,11 +116,11 @@ class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
         return if (parentNode != null && parentFile != null) {
             val expressionOrBodyNode = PsiTreeUtil.findChildOfAnyType(parentNode, KtClassBody::class.java, KtExpressionImpl::class.java)
             val bodyOffset = expressionOrBodyNode?.textOffset ?: parentNode.textOffset + parentNode.textLength
-            val classWithoutBodyText = parentFile.text.substring(parentNode.textOffset, bodyOffset)
+            val headerWithoutBodyText = parentFile.text.substring(parentNode.textOffset, bodyOffset)
             //TODO cover that with tests
             //we also count first opening brace
             val bracketSize = if (expressionOrBodyNode?.firstChild == KtTokens.LBRACE) 1 else 0
-            classWithoutBodyText.length - countLineBreak(classWithoutBodyText) + bracketSize
+            headerWithoutBodyText.length - countLineBreak(headerWithoutBodyText) + bracketSize
         } else {
             0
         }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
-class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
+class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
     private val newLineRegex by lazy { System.lineSeparator().toRegex() }
     private var indentConfig = IndentationConfig(-1, -1, true)
     private var lineLengthConfig = MaxLineLengthConfig(-1)
@@ -65,7 +65,7 @@ class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
                 }
                 if (node.elementType == KtTokens.RPAR) {
                     if (node.treePrev !is PsiWhiteSpace) {
-                        emit(node.startOffset, PARENTHESES_NEW_LINE_ERROR, true)
+                        emit(node.startOffset, PARENTHESIS_NEW_LINE_ERROR, true)
                         if (autoCorrect) {
                             (parentParameterList as CompositeElement).addLeaf(
                                 KtTokens.WHITE_SPACE,
@@ -132,8 +132,8 @@ class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
     }
 
     companion object {
-        const val RULE_ID = "parameters-on-separate-lines"
+        private const val RULE_ID = "class-and-function-header-format"
         private const val MISSED_NEW_LINE_ERROR = "Parameter should be on separate line with indentation"
-        private const val PARENTHESES_NEW_LINE_ERROR = "Parentheses should be on new line"
+        private const val PARENTHESIS_NEW_LINE_ERROR = "Parenthesis should be on new line"
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -69,9 +69,7 @@ class IndentationRule : Rule("indent") {
                         && firstParameter.value?.node != node.nextSibling.node) {
                         if ((line.length + 1) != firstParameterColumn.value) {
                             emit(offset, "Unexpected indentation (${line.length}) (" +
-                                "parameters should be either vertically aligned or " +
-                                "indented by the multiple of $indent" +
-                                ")", true)
+                                "parameters should be vertically aligned)", true)
                         }
                     } else if (line.isNotEmpty() && (line.length - previousIndent) % expectedIndentSize != 0) {
 

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -2,7 +2,6 @@ package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.IndentationConfig
 import com.github.shyiko.ktlint.core.Rule
-import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -25,12 +24,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComme
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class IndentationRule : Rule("indent") {
-
-    companion object {
-        // indentation size recommended by JetBrains
-        private const val DEFAULT_INDENT = 4
-        private const val DEFAULT_CONTINUATION_INDENT = 8
-    }
 
     private var indentConfig = IndentationConfig(-1, -1, true)
 
@@ -116,35 +109,5 @@ class IndentationRule : Rule("indent") {
                 || parentNode is KtSafeQualifiedExpression
                 || parentNode is KtParenthesizedExpression
             )
-    }
-
-    private fun calculatePreviousIndent(node: ASTNode): Int {
-        val parentNode = node.treeParent?.psi
-        var prevIndent = 0
-        var prevSibling = parentNode
-        var prevSpaceIsFound = false
-        while (prevSibling != null && !prevSpaceIsFound) {
-            val nextNode = prevSibling.nextSibling?.node?.elementType
-            if (prevSibling is PsiWhiteSpace
-                && nextNode != KtStubElementTypes.TYPE_REFERENCE
-                && nextNode != KtStubElementTypes.SUPER_TYPE_LIST
-                && nextNode != KtNodeTypes.CONSTRUCTOR_DELEGATION_CALL) {
-                val prevLines = prevSibling.text.split('\n')
-                if (prevLines.size > 1) {
-                    prevIndent = prevLines.last().length
-                    prevSpaceIsFound = true
-                }
-            }
-            prevSibling = if (prevSpaceIsFound) {
-                null
-            } else {
-                if (prevSibling.prevSibling != null) {
-                    prevSibling.prevSibling
-                } else {
-                    prevSibling.parent
-                }
-            }
-        }
-        return prevIndent
     }
 }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -34,9 +34,10 @@ class IndentationRule : Rule("indent") {
 
     private var indentConfig = IndentationConfig(-1, -1, true)
 
-
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             indentConfig = IndentationConfig.create(node)
             return

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -31,7 +31,8 @@ class IndentationRule : Rule("indent") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtStubElementTypes.FILE) {
             indentConfig = IndentationConfig.create(node)
             return

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
             PsiTreeUtil.nextLeaf(node, true)?.node?.elementType == KtTokens.RBRACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -9,8 +9,10 @@ import org.jetbrains.kotlin.lexer.KtTokens
 
 class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
             PsiTreeUtil.nextLeaf(node, true)?.node?.elementType == KtTokens.RBRACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoBlankLineBeforeRbraceRule.kt
@@ -12,7 +12,8 @@ class NoBlankLineBeforeRbraceRule : Rule("no-blank-line-before-rbrace") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is PsiWhiteSpace &&
             node.textContains('\n') &&
             PsiTreeUtil.nextLeaf(node, true)?.node?.elementType == KtTokens.RBRACE) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -11,7 +11,8 @@ class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is PsiWhiteSpace) {
             val split = node.getText().split("\n")
             if (split.size > 3 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val split = node.getText().split("\n")
             if (split.size > 3 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoConsecutiveBlankLinesRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class NoConsecutiveBlankLinesRule : Rule("no-consecutive-blank-lines") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val split = node.getText().split("\n")
             if (split.size > 3 || split.size == 3 && PsiTreeUtil.nextLeaf(node) == null /* eof */) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -47,8 +47,10 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
             }
         }
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             fileNode = node
         } else if (node is PsiWhiteSpace && !node.textContains('\n') && node.getTextLength() > 1) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -50,7 +50,8 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtStubElementTypes.FILE) {
             fileNode = node
         } else if (node is PsiWhiteSpace && !node.textContains('\n') && node.getTextLength() > 1) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoMultipleSpacesRule.kt
@@ -48,7 +48,7 @@ class NoMultipleSpacesRule : Rule("no-multi-spaces") {
         }
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             fileNode = node
         } else

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 class NoSemicolonsRule : Rule("no-semi") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
                 !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -10,8 +10,10 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 
 class NoSemicolonsRule : Rule("no-semi") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
                 !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -13,7 +13,8 @@ class NoSemicolonsRule : Rule("no-semi") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
                 !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
             if (lines.size > 1) {
@@ -28,7 +28,7 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     }
 
     private fun checkForTrailingSpaces(lines: List<String>, offset: Int,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         var violationOffset = offset
         return lines.forEach { line ->
             if (!line.isEmpty()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
             if (lines.size > 1) {
@@ -26,8 +28,10 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
         }
     }
 
-    private fun checkForTrailingSpaces(lines: List<String>, offset: Int,
-                                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    private fun checkForTrailingSpaces(
+        lines: List<String>,
+        offset: Int,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         var violationOffset = offset
         return lines.forEach { line ->
             if (!line.isEmpty()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoTrailingSpacesRule.kt
@@ -11,7 +11,8 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is PsiWhiteSpace) {
             val lines = node.getText().split("\n")
             if (lines.size > 1) {
@@ -31,7 +32,8 @@ class NoTrailingSpacesRule : Rule("no-trailing-spaces") {
     private fun checkForTrailingSpaces(
         lines: List<String>,
         offset: Int,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         var violationOffset = offset
         return lines.forEach { line ->
             if (!line.isEmpty()) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -44,7 +44,8 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtStubElementTypes.FILE) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
             ref.add("*")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -42,7 +42,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private var packageName = ""
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
             ref.add("*")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -41,8 +41,10 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
     private val ref = mutableSetOf<String>()
     private var packageName = ""
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             ref.clear() // rule can potentially be executed more than once (when formatting)
             ref.add("*")

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 class NoWildcardImportsRule : Rule("no-wildcard-imports") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -7,8 +7,10 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class NoWildcardImportsRule : Rule("no-wildcard-imports") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoWildcardImportsRule.kt
@@ -10,7 +10,8 @@ class NoWildcardImportsRule : Rule("no-wildcard-imports") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtStubElementTypes.IMPORT_DIRECTIVE) {
             val importDirective = node.psi as KtImportDirective
             val path = importDirective.importPath?.pathStr

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
@@ -89,11 +89,9 @@ class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
         return parentFile != null && parentParameterList.textRange.substring(parentFile.text).contains("\n")
     }
 
-
     companion object {
         const val RULE_ID = "parameters-on-separate-lines"
         private const val MISSED_NEW_LINE_ERROR = "Parameter should be on separate line with indentation"
         private const val PARENTHESES_NEW_LINE_ERROR = "Parentheses should be on new line"
     }
 }
-

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRule.kt
@@ -1,0 +1,65 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.IndentationConfig
+import com.github.shyiko.ktlint.core.Rule
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeUtil
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+class ParametersOnSeparateLinesRule : Rule(RULE_ID) {
+    private var indentConfig = IndentationConfig(-1, -1, true)
+    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        if (node.elementType == KtStubElementTypes.FILE) {
+            indentConfig = IndentationConfig.create(node)
+            return
+        }
+        val previousIndent: Int by lazy { node.calculatePreviousIndent() }
+        val parentParameterList = node.treeParent
+        if (parentParameterList?.elementType == KtStubElementTypes.VALUE_PARAMETER_LIST
+            //do not enforce lambda parameters
+            && parentParameterList.treeParent?.elementType != KtNodeTypes.FUNCTION_LITERAL) {
+            val parentFile = TreeUtil.findParent(node, KtStubElementTypes.FILE)
+            if (parentFile != null
+                && node.elementType == KtStubElementTypes.VALUE_PARAMETER
+                && parentParameterList.textRange.substring(parentFile.text).contains("\n")
+                && node is CompositeElement) {
+                if (node.treePrev !is PsiWhiteSpace) {
+                    emit(node.startOffset, MISSED_NEW_LINE_ERROR, true)
+                    if (autoCorrect) {
+                        (parentParameterList as CompositeElement).addLeaf(
+                            KtTokens.WHITE_SPACE,
+                            "\n" + " ".repeat(previousIndent + indentConfig.regular),
+                            node)
+                    }
+                } else {
+                    val prevText = node.treePrev.text
+                    if (!prevText.startsWith("\n")) {
+                        emit(node.startOffset, MISSED_NEW_LINE_ERROR, true)
+                        if (autoCorrect) {
+                            (node.treePrev as LeafPsiElement)
+                                .rawReplaceWithText("\n" + " ".repeat(previousIndent + indentConfig.regular))
+                        }
+                    } else if (prevText.length - previousIndent - 1 != indentConfig.regular) {
+                        emit(node.startOffset,
+                            "Unexpected indentation for parameter ${prevText.length - previousIndent - 1} (should be ${indentConfig.regular})",
+                            true)
+                        if (autoCorrect) {
+                            (node.treePrev as LeafPsiElement)
+                                .rawReplaceWithText("\n" + " ".repeat(previousIndent + indentConfig.regular))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val RULE_ID = "parameters-on-separate-lines"
+        private const val MISSED_NEW_LINE_ERROR = "Parameter should be on separate line with indentation"
+    }
+}

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -14,8 +14,10 @@ import org.jetbrains.kotlin.psi.KtTypeParameterList
 
 class SpacingAroundColonRule : Rule("colon-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString()) {
             if (node.isPartOf(KtAnnotation::class) || node.isPartOf(KtAnnotationEntry::class)) {
                 // todo: enfore "no spacing"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtTypeParameterList
 class SpacingAroundColonRule : Rule("colon-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString()) {
             if (node.isPartOf(KtAnnotation::class) || node.isPartOf(KtAnnotationEntry::class)) {
                 // todo: enfore "no spacing"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundColonRule.kt
@@ -17,7 +17,8 @@ class SpacingAroundColonRule : Rule("colon-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is LeafPsiElement && node.textMatches(":") && !node.isPartOfString()) {
             if (node.isPartOf(KtAnnotation::class) || node.isPartOf(KtAnnotationEntry::class)) {
                 // todo: enfore "no spacing"

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -9,8 +9,10 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class SpacingAroundCommaRule : Rule("comma-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString() &&
             PsiTreeUtil.nextLeaf(node) !is PsiWhiteSpace) {
             emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -12,7 +12,8 @@ class SpacingAroundCommaRule : Rule("comma-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString() &&
             PsiTreeUtil.nextLeaf(node) !is PsiWhiteSpace) {
             emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCommaRule.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 class SpacingAroundCommaRule : Rule("comma-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches(",") && !node.isPartOfString() &&
             PsiTreeUtil.nextLeaf(node) !is PsiWhiteSpace) {
             emit(node.startOffset + 1, "Missing spacing after \"${node.text}\"", true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -13,8 +13,10 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -16,7 +16,8 @@ class SpacingAroundCurlyRule : Rule("curly-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundCurlyRule.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtLambdaExpression
 class SpacingAroundCurlyRule : Rule("curly-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && !node.isPartOfString()) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -32,7 +32,8 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
 
         if (node is LeafPsiElement) {
             if (tokenSet.contains(node.elementType) && node.nextLeaf() !is PsiWhiteSpace) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundKeywordRule.kt
@@ -29,8 +29,10 @@ class SpacingAroundKeywordRule : Rule("keyword-spacing") {
 
     private val keywordsWithoutSpaces = TokenSet.create(KtTokens.GET_KEYWORD, KtTokens.SET_KEYWORD)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
 
         if (node is LeafPsiElement) {
             if (tokenSet.contains(node.elementType) && node.nextLeaf() !is PsiWhiteSpace) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -45,7 +45,7 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
         EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW)
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -44,8 +44,10 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
     private val tokenSet = TokenSet.create(MUL, PLUS, MINUS, DIV, PERC, LT, GT, LTEQ, GTEQ, EQEQEQ, EXCLEQEQEQ, EQEQ,
         EXCLEQ, ANDAND, OROR, ELVIS, EQ, MULTEQ, DIVEQ, PERCEQ, PLUSEQ, MINUSEQ, ARROW)
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundOperatorsRule.kt
@@ -47,7 +47,8 @@ class SpacingAroundOperatorsRule : Rule("op-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (tokenSet.contains(node.elementType) && node is LeafPsiElement &&
             !node.isPartOf(KtPrefixExpression::class) && // not unary
             !node.isPartOf(KtTypeArgumentList::class) && // C<T>

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-            emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtTokens.RANGE) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node.psi, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node.psi, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.lexer.KtTokens
 
 class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node.elementType == KtTokens.RANGE) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node.psi, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node.psi, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/SpacingAroundRangeOperatorRule.kt
@@ -11,7 +11,8 @@ class SpacingAroundRangeOperatorRule : Rule("range-spacing") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtTokens.RANGE) {
             val prevLeaf = PsiTreeUtil.prevLeaf(node.psi, true)
             val nextLeaf = PsiTreeUtil.nextLeaf(node.psi, true)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -11,7 +11,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         // disabled until it's clear how to reconcile difference in Intellij & Android Studio import layout
         // ImportOrderingRule(),
         NoLineBreakAfterElseRule(),
-        ParametersOnSeparateLinesRule(),
+        ClassAndFunctionHeaderFormatRule(),
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -11,6 +11,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         // disabled until it's clear how to reconcile difference in Intellij & Android Studio import layout
         // ImportOrderingRule(),
         NoLineBreakAfterElseRule(),
+        ParametersOnSeparateLinesRule(),
         IndentationRule(),
         MaxLineLengthRule(),
         ModifierOrderRule(),

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/package.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/package.kt
@@ -1,8 +1,12 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
+import org.jetbrains.kotlin.KtNodeTypes
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import kotlin.reflect.KClass
 
 internal fun PsiElement.isPartOf(clazz: KClass<out PsiElement>) = getNonStrictParentOfType(clazz.java) != null
@@ -10,3 +14,33 @@ internal fun PsiElement.isPartOfString() = isPartOf(KtStringTemplateEntry::class
 
 internal fun <T> List<T>.head() = this.subList(0, this.size - 1)
 internal fun <T> List<T>.tail() = this.subList(1, this.size)
+
+internal fun ASTNode.calculatePreviousIndent(): Int {
+    val parentNode = this.treeParent?.psi
+    var prevIndent = 0
+    var prevSibling = parentNode
+    var prevSpaceIsFound = false
+    while (prevSibling != null && !prevSpaceIsFound) {
+        val nextNode = prevSibling.nextSibling?.node?.elementType
+        if (prevSibling is PsiWhiteSpace
+            && nextNode != KtStubElementTypes.TYPE_REFERENCE
+            && nextNode != KtStubElementTypes.SUPER_TYPE_LIST
+            && nextNode != KtNodeTypes.CONSTRUCTOR_DELEGATION_CALL) {
+            val prevLines = prevSibling.text.split('\n')
+            if (prevLines.size > 1) {
+                prevIndent = prevLines.last().length
+                prevSpaceIsFound = true
+            }
+        }
+        prevSibling = if (prevSpaceIsFound) {
+            null
+        } else {
+            if (prevSibling.prevSibling != null) {
+                prevSibling.prevSibling
+            } else {
+                prevSibling.parent
+            }
+        }
+    }
+    return prevIndent
+}

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRuleTest.kt
@@ -6,18 +6,18 @@ import com.github.shyiko.ktlint.test.lint
 import org.assertj.core.api.Assertions
 import org.testng.annotations.Test
 
-class ParametersOnSeparateLinesRuleTest {
-    private val expectedErrorMessage = "Parameter should be on separate line with indentation"
-    private val expectedParenthesesMessage = "Parentheses should be on new line"
-    private val expectedRuleId = ParametersOnSeparateLinesRule.RULE_ID
+class ClassAndFunctionHeaderFormatRuleTest {
+    private val errorMessageMissedNewLineForParameter = "Parameter should be on separate line with indentation"
+    private val errorMessageMissedNewLineForParenthesis = "Parenthesis should be on new line"
+    private val expectedRuleId = "class-and-function-header-format"
     private val configUserData = mapOf("indent_size" to "4", "continuation_indent_size" to "6")
-    private fun expectedIndentErrorMessage(actualInden: Int, expectedIndent: Int): String {
-        return "Unexpected indentation for parameter $actualInden (should be $expectedIndent)"
+    private fun errorMessageWhenWrongIndent(actualIndent: Int, expectedIndent: Int): String {
+        return "Unexpected indentation for parameter $actualIndent (should be $expectedIndent)"
     }
 
     @Test
     fun testClassWithAbsentLineBreak() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(paramA: String, paramB: String,
                          paramC: String)
@@ -25,16 +25,16 @@ class ParametersOnSeparateLinesRuleTest {
             configUserData
         )).isEqualTo(
             listOf(
-                LintError(1, 14, expectedRuleId, expectedErrorMessage),
-                LintError(1, 30, expectedRuleId, expectedErrorMessage),
-                LintError(2, 14, expectedRuleId, expectedIndentErrorMessage(13, 4)),
-                LintError(2, 28, expectedRuleId, expectedParenthesesMessage))
+                LintError(1, 14, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(1, 30, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(2, 14, expectedRuleId, errorMessageWhenWrongIndent(13, 4)),
+                LintError(2, 28, expectedRuleId, errorMessageMissedNewLineForParenthesis))
         )
     }
 
     @Test
     fun testFormatClassWithAbsentLineBreak() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class ClassA(paramA: String, paramB: String,
                          paramC: String)
@@ -53,7 +53,7 @@ class ParametersOnSeparateLinesRuleTest {
 
     @Test
     fun testValidClassDefinitionWithMultipleLines() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(
                 paramA: String,
@@ -67,7 +67,7 @@ class ParametersOnSeparateLinesRuleTest {
 
     @Test
     fun testValidClassDefinitionOnOneLine() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(paramA: String, paramB: String, paramC: String)
             """.trimIndent(),
@@ -77,7 +77,7 @@ class ParametersOnSeparateLinesRuleTest {
 
     @Test
     fun testErrorWhenFirstParameterIsNotOnNewLine() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             fun f(a: Any,
                   b: Any,
@@ -87,17 +87,17 @@ class ParametersOnSeparateLinesRuleTest {
             configUserData
         )).isEqualTo(
             listOf(
-                LintError(1, 7, expectedRuleId, expectedErrorMessage),
-                LintError(2, 7, expectedRuleId, expectedIndentErrorMessage(6, 4)),
-                LintError(3, 7, expectedRuleId, expectedIndentErrorMessage(6, 4)),
-                LintError(3, 13, expectedRuleId, expectedParenthesesMessage)
+                LintError(1, 7, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(2, 7, expectedRuleId, errorMessageWhenWrongIndent(6, 4)),
+                LintError(3, 7, expectedRuleId, errorMessageWhenWrongIndent(6, 4)),
+                LintError(3, 13, expectedRuleId, errorMessageMissedNewLineForParenthesis)
             )
         )
     }
 
     @Test
     fun testFormatWhenFirstParameterIsNoOnNewLine() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             fun f(a: Any,
                   b: Any,
@@ -119,7 +119,7 @@ class ParametersOnSeparateLinesRuleTest {
 
     @Test
     fun testIgnoreLambdaParameters() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             val fieldExample =
                   LongNameClass { paramA,
@@ -134,7 +134,7 @@ class ParametersOnSeparateLinesRuleTest {
 
     @Test
     fun testFailWhenWrongIndentIsUsed() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class A {
                 fun f(
@@ -146,16 +146,16 @@ class ParametersOnSeparateLinesRuleTest {
             configUserData
         )).isEqualTo(
             listOf(
-                LintError(3, 8, expectedRuleId, expectedIndentErrorMessage(3, 4)),
-                LintError(4, 8, expectedRuleId, expectedIndentErrorMessage(3, 4)),
-                LintError(4, 14, expectedRuleId, expectedParenthesesMessage)
+                LintError(3, 8, expectedRuleId, errorMessageWhenWrongIndent(3, 4)),
+                LintError(4, 8, expectedRuleId, errorMessageWhenWrongIndent(3, 4)),
+                LintError(4, 14, expectedRuleId, errorMessageMissedNewLineForParenthesis)
             )
         )
     }
 
     @Test
     fun testRespectOuterIndent() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class A {
                 fun f(a: Any,
@@ -180,8 +180,35 @@ class ParametersOnSeparateLinesRuleTest {
     }
 
     @Test
+    fun testRespectOuterIndentWhenCalculateParanthesisIndent() {
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+            """
+            class A {
+                fun f(a: Any,
+                      b: Any,
+                      c: Any
+                   ) {
+                }
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            class A {
+                fun f(
+                    a: Any,
+                    b: Any,
+                    c: Any
+                ) {
+                }
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
     fun testFailWhenHeaderIsTooLong() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class WithLongClassHeader(parameter1: Int, parameter2: Int, parameter3: Int) {
               fun a() = ""
@@ -190,17 +217,17 @@ class ParametersOnSeparateLinesRuleTest {
             mapOf("max_line_length" to "50")
         )).isEqualTo(
             listOf(
-                LintError(1, 27, expectedRuleId, expectedErrorMessage),
-                LintError(1, 44, expectedRuleId, expectedErrorMessage),
-                LintError(1, 61, expectedRuleId, expectedErrorMessage),
-                LintError(1, 76, expectedRuleId, expectedParenthesesMessage)
+                LintError(1, 27, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(1, 44, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(1, 61, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(1, 76, expectedRuleId, errorMessageMissedNewLineForParenthesis)
             )
         )
     }
 
     @Test
     fun testFormatClassWithAllCases() {
-        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class WithLongClassHeader(parameter1: Int, parameter2: Int, parameter3: Int) {
                 constructor(parameter1: Int, parameter2: Int, parameter3: Int) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -550,7 +550,7 @@ class IndentationRuleTest {
     }
 
     @Test
-    fun testAutoCorrectionIsDisabledForParameters() {
+    fun shouldAlignParameters() {
         assertThat(IndentationRule().format(
             """
             fun funA(a: A,
@@ -563,7 +563,7 @@ class IndentationRuleTest {
         )).isEqualTo(
             """
             fun funA(a: A,
-             b: B) {
+                     b: B) {
                 return ""
             }
             """.trimIndent()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -140,7 +140,8 @@ class IndentationRuleTest {
             """.trimIndent(),
             script = true
         )).isEqualTo(listOf(
-            LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)")
+            LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)"),
+            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be either vertically aligned or indented by the multiple of 4)")
         ))
     }
 
@@ -503,6 +504,22 @@ class IndentationRuleTest {
                   // comment
                   // comment
                   call(argA)
+            """.trimIndent(),
+            mapOf("indent_size" to "4",
+                "continuation_indent_size" to "6")
+        )).isEmpty()
+    }
+
+    @Test
+    fun testLambdaParametersShouldBeAligned() {
+        assertThat(IndentationRule().lint(
+            """
+            val fieldExample =
+                  LongNameClass { paramA,
+                                  paramB,
+                                  paramC ->
+                      ClassB(paramA, paramB, paramC)
+                  }
             """.trimIndent(),
             mapOf("indent_size" to "4",
                 "continuation_indent_size" to "6")

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -141,7 +141,7 @@ class IndentationRuleTest {
             script = true
         )).isEqualTo(listOf(
             LintError(2, 1, "indent", "Unexpected indentation (5) (it should be 4)"),
-            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be either vertically aligned or indented by the multiple of 4)")
+            LintError(3, 1, "indent", "Unexpected indentation (4) (parameters should be vertically aligned)")
         ))
     }
 

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
@@ -8,6 +8,7 @@ import org.testng.annotations.Test
 
 class ParametersOnSeparateLinesRuleTest {
     private val expectedErrorMessage = "Parameter should be on separate line with indentation"
+    private val expectedParenthesesMessage = "Parentheses should be on new line"
     private val configUserData = mapOf("indent_size" to "4", "continuation_indent_size" to "6")
     private fun expectedIndentErrorMessage(actualInden: Int, expectedIndent: Int): String {
         return "Unexpected indentation for parameter $actualInden (should be $expectedIndent)"
@@ -25,7 +26,8 @@ class ParametersOnSeparateLinesRuleTest {
             listOf(
                 LintError(1, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
                 LintError(1, 30, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
-                LintError(2, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(13, 4)))
+                LintError(2, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(13, 4)),
+                LintError(2, 28, ParametersOnSeparateLinesRule.RULE_ID, expectedParenthesesMessage))
         )
     }
 
@@ -42,7 +44,8 @@ class ParametersOnSeparateLinesRuleTest {
             class ClassA(
                 paramA: String,
                 paramB: String,
-                paramC: String)
+                paramC: String
+            )
             """.trimIndent()
         )
     }
@@ -54,7 +57,8 @@ class ParametersOnSeparateLinesRuleTest {
             class ClassA(
                 paramA: String,
                 paramB: String,
-                paramC: String)
+                paramC: String
+            )
             """.trimIndent(),
             configUserData
         )).isEmpty()
@@ -84,13 +88,36 @@ class ParametersOnSeparateLinesRuleTest {
             listOf(
                 LintError(1, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
                 LintError(2, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4)),
-                LintError(3, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4))
+                LintError(3, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4)),
+                LintError(3, 13, ParametersOnSeparateLinesRule.RULE_ID, expectedParenthesesMessage)
             )
         )
     }
 
     @Test
-    fun testLambdaParameters() {
+    fun testFormatWhenFirstParameterIsNoOnNewLine() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+            """
+            fun f(a: Any,
+                  b: Any,
+                  c: Any) {
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            fun f(
+                a: Any,
+                b: Any,
+                c: Any
+            ) {
+            }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testIgnoreLambdaParameters() {
         Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
             """
             val fieldExample =
@@ -119,7 +146,8 @@ class ParametersOnSeparateLinesRuleTest {
         )).isEqualTo(
             listOf(
                 LintError(3, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4)),
-                LintError(4, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4))
+                LintError(4, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4)),
+                LintError(4, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedParenthesesMessage)
             )
         )
     }
@@ -142,7 +170,8 @@ class ParametersOnSeparateLinesRuleTest {
                 fun f(
                     a: Any,
                     b: Any,
-                    c: Any) {
+                    c: Any
+                ) {
                 }
             }
             """.trimIndent()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParametersOnSeparateLinesRuleTest.kt
@@ -1,0 +1,151 @@
+package com.github.shyiko.ktlint.ruleset.standard
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.format
+import com.github.shyiko.ktlint.test.lint
+import org.assertj.core.api.Assertions
+import org.testng.annotations.Test
+
+class ParametersOnSeparateLinesRuleTest {
+    private val expectedErrorMessage = "Parameter should be on separate line with indentation"
+    private val configUserData = mapOf("indent_size" to "4", "continuation_indent_size" to "6")
+    private fun expectedIndentErrorMessage(actualInden: Int, expectedIndent: Int): String {
+        return "Unexpected indentation for parameter $actualInden (should be $expectedIndent)"
+    }
+
+    @Test
+    fun testClassWithAbsentLineBreak() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(paramA: String, paramB: String,
+                         paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(1, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(1, 30, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(2, 14, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(13, 4)))
+        )
+    }
+
+    @Test
+    fun testFormatClassWithAbsentLineBreak() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+            """
+            class ClassA(paramA: String, paramB: String,
+                         paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            class ClassA(
+                paramA: String,
+                paramB: String,
+                paramC: String)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testValidClassDefinitionWithMultipleLines() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(
+                paramA: String,
+                paramB: String,
+                paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testValidClassDefinitionOnOneLine() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class ClassA(paramA: String, paramB: String, paramC: String)
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testErrorWhenFirstParameterIsNotOnNewLine() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            fun f(a: Any,
+                  b: Any,
+                  c: Any) {
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(1, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedErrorMessage),
+                LintError(2, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4)),
+                LintError(3, 7, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(6, 4))
+            )
+        )
+    }
+
+    @Test
+    fun testLambdaParameters() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            val fieldExample =
+                  LongNameClass { paramA,
+                                  paramB,
+                                  paramC ->
+                      ClassB(paramA, paramB, paramC)
+                  }
+            """.trimIndent(),
+            configUserData
+        )).isEmpty()
+    }
+
+    @Test
+    fun testFailWhenWrongIndentIsUsed() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().lint(
+            """
+            class A {
+                fun f(
+                   a: Any,
+                   b: Any) {
+                }
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            listOf(
+                LintError(3, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4)),
+                LintError(4, 8, ParametersOnSeparateLinesRule.RULE_ID, expectedIndentErrorMessage(3, 4))
+            )
+        )
+    }
+
+    @Test
+    fun testRespectOuterIndent() {
+        Assertions.assertThat(ParametersOnSeparateLinesRule().format(
+            """
+            class A {
+                fun f(a: Any,
+                      b: Any,
+                      c: Any) {
+                }
+            }
+            """.trimIndent(),
+            configUserData
+        )).isEqualTo(
+            """
+            class A {
+                fun f(
+                    a: Any,
+                    b: Any,
+                    c: Any) {
+                }
+            }
+            """.trimIndent()
+        )
+    }
+}

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 class NoVarRule : Rule("no-var") {
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches("var") &&
                 getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
             emit(node.startOffset, "Unexpected var, use val instead", false)

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -11,7 +11,8 @@ class NoVarRule : Rule("no-var") {
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
         if (node is LeafPsiElement && node.textMatches("var") &&
                 getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
             emit(node.startOffset, "Unexpected var, use val instead", false)

--- a/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
+++ b/ktlint-ruleset-template/src/main/kotlin/yourpkgname/NoVarRule.kt
@@ -8,8 +8,10 @@ import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 
 class NoVarRule : Rule("no-var") {
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {
         if (node is LeafPsiElement && node.textMatches("var") &&
                 getNonStrictParentOfType(node, KtStringTemplateEntry::class.java) == null) {
             emit(node.startOffset, "Unexpected var, use val instead", false)

--- a/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
+++ b/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
@@ -23,7 +23,7 @@ class DumpAST @JvmOverloads constructor(
     private var lastNode: ASTNode? = null
 
     override fun visit(node: ASTNode, autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+                       emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             lineNumberColumnLength = (location(PsiTreeUtil.getDeepestLast(node.psi).node)?.line ?: 0)
                 .let { var v = it; var c = 0; while (v > 0) { c++; v /= 10 }; c }

--- a/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
+++ b/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
@@ -25,7 +25,8 @@ class DumpAST @JvmOverloads constructor(
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit
+    ) {
         if (node.elementType == KtStubElementTypes.FILE) {
             lineNumberColumnLength = (location(PsiTreeUtil.getDeepestLast(node.psi).node)?.line ?: 0)
                 .let { var v = it; var c = 0; while (v > 0) { c++; v /= 10 }; c }

--- a/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
+++ b/ktlint-test/src/main/kotlin/com/github/shyiko/ktlint/test/package.kt
@@ -22,8 +22,10 @@ class DumpAST @JvmOverloads constructor(
     private var lineNumberColumnLength: Int = 0
     private var lastNode: ASTNode? = null
 
-    override fun visit(node: ASTNode, autoCorrect: Boolean,
-                       emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, corrected: Boolean) -> Unit) {
         if (node.elementType == KtStubElementTypes.FILE) {
             lineNumberColumnLength = (location(PsiTreeUtil.getDeepestLast(node.psi).node)?.line ?: 0)
                 .let { var v = it; var c = 0; while (v > 0) { c++; v /= 10 }; c }

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -583,12 +583,12 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         }
 
     private fun lint(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError) -> Unit) =
+                     cb: (e: LintError) -> Unit) =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.lint(text, ruleSets, userData, cb) else
             KtLint.lintScript(text, ruleSets, userData, cb)
 
     private fun format(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError, corrected: Boolean) -> Unit): String =
+                       cb: (e: LintError, corrected: Boolean) -> Unit): String =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.format(text, ruleSets, userData, cb) else
             KtLint.formatScript(text, ruleSets, userData, cb)
 
@@ -599,7 +599,7 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
     }
 
     private fun <T> Sequence<Callable<T>>.parallel(cb: (T) -> Unit,
-        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
+                                                   numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
         val q = ArrayBlockingQueue<Future<T>>(numberOfThreads)
         val pill = object : Future<T> {
 

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -585,7 +585,8 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         text: String,
         ruleSets: Iterable<RuleSet>,
         userData: Map<String, String>,
-        cb: (e: LintError) -> Unit) =
+        cb: (e: LintError) -> Unit
+    ) =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.lint(text, ruleSets, userData, cb) else KtLint.lintScript(text, ruleSets, userData, cb)
 
     private fun format(
@@ -593,7 +594,8 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         text: String,
         ruleSets: Iterable<RuleSet>,
         userData: Map<String, String>,
-        cb: (e: LintError, corrected: Boolean) -> Unit): String =
+        cb: (e: LintError, corrected: Boolean) -> Unit
+    ): String =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.format(text, ruleSets, userData, cb) else KtLint.formatScript(text, ruleSets, userData, cb)
 
     private fun java.net.URLClassLoader.addURLs(url: Iterable<java.net.URL>) {
@@ -604,7 +606,8 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
 
     private fun <T> Sequence<Callable<T>>.parallel(
         cb: (T) -> Unit,
-        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
+        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()
+    ) {
         val q = ArrayBlockingQueue<Future<T>>(numberOfThreads)
         val pill = object : Future<T> {
 

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -580,12 +580,20 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
             map
         }
 
-    private fun lint(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError) -> Unit) =
+    private fun lint(
+        fileName: String,
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError) -> Unit) =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.lint(text, ruleSets, userData, cb) else KtLint.lintScript(text, ruleSets, userData, cb)
 
-    private fun format(fileName: String, text: String, ruleSets: Iterable<RuleSet>, userData: Map<String, String>,
-            cb: (e: LintError, corrected: Boolean) -> Unit): String =
+    private fun format(
+        fileName: String,
+        text: String,
+        ruleSets: Iterable<RuleSet>,
+        userData: Map<String, String>,
+        cb: (e: LintError, corrected: Boolean) -> Unit): String =
         if (fileName.endsWith(".kt", ignoreCase = true)) KtLint.format(text, ruleSets, userData, cb) else KtLint.formatScript(text, ruleSets, userData, cb)
 
     private fun java.net.URLClassLoader.addURLs(url: Iterable<java.net.URL>) {
@@ -594,8 +602,9 @@ ${ByteArrayOutputStream().let { this.printUsage(it); it }.toString().trimEnd().s
         url.forEach { method.invoke(this, it) }
     }
 
-    private fun <T> Sequence<Callable<T>>.parallel(cb: (T) -> Unit,
-                                                   numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
+    private fun <T> Sequence<Callable<T>>.parallel(
+        cb: (T) -> Unit,
+        numberOfThreads: Int = Runtime.getRuntime().availableProcessors()) {
         val q = ArrayBlockingQueue<Future<T>>(numberOfThreads)
         val pill = object : Future<T> {
 

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
@@ -25,7 +25,8 @@ import java.io.File
 class MavenDependencyResolver(
     baseDir: File,
     val repositories: Iterable<RemoteRepository>,
-    forceUpdate: Boolean) {
+    forceUpdate: Boolean
+) {
 
     private val repoSystem: RepositorySystem
     private val session: RepositorySystemSession

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
@@ -22,8 +22,10 @@ import org.eclipse.aether.transport.http.HttpTransporterFactory
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.io.File
 
-class MavenDependencyResolver(baseDir: File, val repositories: Iterable<RemoteRepository>,
-                              forceUpdate: Boolean) {
+class MavenDependencyResolver(
+    baseDir: File,
+    val repositories: Iterable<RemoteRepository>,
+    forceUpdate: Boolean) {
 
     private val repoSystem: RepositorySystem
     private val session: RepositorySystemSession

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/MavenDependencyResolver.kt
@@ -23,7 +23,7 @@ import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator
 import java.io.File
 
 class MavenDependencyResolver(baseDir: File, val repositories: Iterable<RemoteRepository>,
-    forceUpdate: Boolean) {
+                              forceUpdate: Boolean) {
 
     private val repoSystem: RepositorySystem
     private val session: RepositorySystemSession


### PR DESCRIPTION
#### This PR contains
* new rule `ClassAndFunctionHeaderFormatRule`  that implements #130 
* autocorrection for `IndentionRule` (fixes for #116)

Changes from #126  and #118 are included into current PR.

#### New rule notes
Applies to class definition (eg. primary constructor), secondary constructor and function.
Wrapping is needed in two cases:
* line break is already present
* overall header length exceeds maximum allowed line length

#### Example

```kotlin
class WithLongClassHeader(parameter1: Int, parameter2: Int, parameter3: Int) {
    constructor(parameter1: Int, parameter2: Int, parameter3: Int) {
    }

    fun withLongDefinition(param1: Int, parameter2: Int, parameter3: Int): String {
        return " "
    }
}
```

becomes this

```kotlin
class WithLongClassHeader(
    parameter1: Int,
    parameter2: Int,
    parameter3: Int
) {
    constructor(
        parameter1: Int,
        parameter2: Int,
        parameter3: Int
    ) {
    }

    fun withLongDefinition(
        param1: Int,
        parameter2: Int,
        parameter3: Int
    ): String {
        return " "
    }
}
```

See tests for more examples