### PR TITLE
IndentationRule: fix auto correction

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -75,7 +75,7 @@ class IndentationRule : Rule("indent") {
                             "Unexpected indentation (${line.length - previousIndent}) " +
                                 "(it should be $expectedIndentSize)",
                             true)
-                        if (autoCorrect) replaceWithExpectedIndent(node, expectedIndentSize)
+                        if (autoCorrect) replaceWithExpectedIndent(node, previousIndent + expectedIndentSize)
                     }
                     offset += line.length + 1
                 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -585,4 +585,33 @@ class IndentationRuleTest {
                 "continuation_indent_size" to "6")
         )).isEmpty()
     }
+
+    @Test
+    fun shouldRespectPreviousIntent() {
+        assertThat(
+            IndentationRule().format(
+                """
+            fun setUp() {
+                 helper = ClassA(
+                    paramA,
+                    paramB
+                )
+            }
+            """.trimIndent(),
+                mapOf(
+                    "indent_size" to "4",
+                    "continuation_indent_size" to "6"
+                )
+            )
+        ).isEqualTo(
+            """
+            fun setUp() {
+                helper = ClassA(
+                      paramA,
+                      paramB
+                )
+            }
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Corrected whitespace should be equal to expected indent + previous indent

Fixes #116 

@shyiko Would it be possible to release 0.15.1 fix with these changes?

PS. 
While testing I've found some cases when `IndentionRule` doesn't report violation. Also on my code base I had to apply `detektFormat` twice. 
These two are not trivial to fix. I'll describe them later in a separate issue.