### PR TITLE
Fix erroneous unused import flagging on custom destructure operators

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRule.kt
@@ -12,6 +12,8 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class NoUnusedImportsRule : Rule("no-unused-imports") {
 
+    private val destructureOperator = Regex("(?:component)[\\d]+\\b")
+
     private val operatorSet = setOf(
         // unary
         "unaryPlus", "unaryMinus", "not",
@@ -34,9 +36,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
         // iteration (https://github.com/shyiko/ktlint/issues/40)
         "iterator",
         // by (https://github.com/shyiko/ktlint/issues/54)
-        "getValue", "setValue",
-        // destructuring assignment
-        "component1", "component2", "component3", "component4", "component5"
+        "getValue", "setValue"
     )
     private val ref = mutableSetOf<String>()
     private var packageName = ""
@@ -74,7 +74,7 @@ class NoUnusedImportsRule : Rule("no-unused-imports") {
                 if (autoCorrect) {
                     importDirective.delete()
                 }
-            } else if (name != null && !ref.contains(name) && !operatorSet.contains(name)) {
+            } else if (name != null && !ref.contains(name) && !operatorSet.contains(name) && !destructureOperator.matches(name)) {
                 emit(importDirective.startOffset, "Unused import", true)
                 if (autoCorrect) {
                     importDirective.delete()

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoUnusedImportsRuleTest.kt
@@ -48,6 +48,35 @@ class NoUnusedImportsRuleTest {
     }
 
     @Test
+    fun testDestructureOperatorLint() {
+        assertThat(NoUnusedImportsRule().lint(
+            """
+            import p.component6
+
+            fun main() {
+                val (one, two, three, four, five, six) = someList
+            }
+            """.trimIndent()
+        )).isEmpty()
+        assertThat(NoUnusedImportsRule().lint(
+            """
+            import p.component6
+            import p.component2
+            import p.component100
+            import p.component
+            import p.component12woohoo
+
+            fun main() {
+                val (one, two, three, four, five, six) = someList
+            }
+            """.trimIndent()
+        )).isEqualTo(listOf(
+            LintError(4, 1, "no-unused-imports", "Unused import"),
+            LintError(5, 1, "no-unused-imports", "Unused import")
+        ))
+    }
+
+    @Test
     fun testLintKDocLinkImport() {
         assertThat(NoUnusedImportsRule().lint(
             """


### PR DESCRIPTION
I noticed a bug with the unused import rule when I initially integrated in KtLint into one of my projects. It erroneously detected custom componentN operators as unused (which the auto formatter ended up removing and breaking my build :()

The Kotlin std library by default only provides `component1()` up to `component5()`, meaning that you can only destructure up to 5 values by default. See https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/index.html and search for "component5" for reference

So if someone wants to destructure six values, i.e.:

`(one, two, three, four, five, six) = someList`

... the IDE will throw an error since `component6()` doesn't exist. To get around this you can write your own component6() method pretty easily:

`inline operator fun <T> List<T>.component6() = get(5)`

.. and when this method is imported it's flagged by KtLint as unused since the unused import rule only checks for the default destructure methods (component1...5()).

To solve this I added a regex that'll match against componentN (where N is some number) and ignore the normal unused import checking.

I'm also open to suggestions if you think there is a better way of handling this case.