### PR TITLE
Complete gradle build of ktlint.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,12 @@ ext.libraries = [
   "aether_transport_file": "org.eclipse.aether:aether-transport-file:1.1.0",
   "aether_transport_http": "org.eclipse.aether:aether-transport-http:1.1.0",
   "aether_connector_basic": "org.eclipse.aether:aether-connector-basic:1.1.0",
+  "kolor": "com.andreapivetta.kolor:kolor:0.0.2",
 
   // Testing libraries
   "testng": "org.testng:testng:6.8.21",
   "assertj_core": "org.assertj:assertj-core:1.7.1",
+  "jimfs": "com.google.jimfs:jimfs:1.1"
 ]
 
 subprojects {

--- a/ktlint-reporter-plain/build.gradle
+++ b/ktlint-reporter-plain/build.gradle
@@ -5,6 +5,7 @@ plugins {
 dependencies {
   compile project(':ktlint-core')
   compile libraries.kotlin_stdlib
+  compile libraries.kolor
 
   testCompile libraries.testng
   testCompile libraries.assertj_core

--- a/ktlint-test/build.gradle
+++ b/ktlint-test/build.gradle
@@ -5,4 +5,5 @@ plugins {
 dependencies {
   compile project(':ktlint-core')
   compile libraries.kotlin_stdlib
+  compile libraries.kolor
 }

--- a/ktlint/build.gradle
+++ b/ktlint/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+  id "com.github.johnrengelman.shadow" version "2.0.2"
   id "org.jetbrains.kotlin.jvm"
 }
 
@@ -20,4 +21,17 @@ dependencies {
   compile libraries.aether_transport_file
   compile libraries.aether_transport_http
   compile libraries.aether_connector_basic
+
+  testCompile libraries.testng
+  testCompile libraries.assertj_core
+  testCompile libraries.jimfs
+}
+
+compileKotlin {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }


### PR DESCRIPTION
- Add new dependencies needed to build/test ktlint
  (missed these due to my branch being out of date)
- Set jar target level be java 8.
- Added shadowjar plugin that allows to build uber jar
  for running ktlint.
  Use: ./gradlew shadowJar
  Then use ktlint/build/libs/ktlint-all.jar