### PR TITLE
Add the packaging metadata to build the ktlint snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: ktlint
+version: git
+summary: An anti-bikeshedding Kotlin linter with built-in formatter
+description: |
+   Kotlin linter in spirit of feross/standard (JavaScript) and gofmt (Go).
+
+confinement: devmode
+
+apps:
+  ktlint:
+    command: java -jar $SNAP/ktlint-0.0.0-SNAPSHOT-shaded.jar
+    plugs: [home]
+    environment:
+      PATH: $PATH:$SNAP/usr/lib/jvm/java-8-openjdk-amd64/bin
+
+parts:
+  ktlint:
+    source: .
+    plugin: nil
+    build-packages: [openjdk-8-jdk]
+    stage-packages: [openjdk-8-jre]
+    build: |
+      ./mvnw
+      ./mvnw -Pcapsule clean package -Dmaven.test.skip=true
+    install:
+      mv ktlint/target/ktlint-0.0.0-SNAPSHOT-shaded.jar $SNAPCRAFT_PART_INSTALL

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: devmode
 
 apps:
   ktlint:
-    command: java -jar $SNAP/ktlint-0.0.0-SNAPSHOT-shaded.jar
+    command: ktlint
     plugs: [home]
     environment:
       PATH: $PATH:$SNAP/usr/lib/jvm/java-8-openjdk-amd64/bin
@@ -20,7 +20,6 @@ parts:
     build-packages: [openjdk-8-jdk]
     stage-packages: [openjdk-8-jre]
     build: |
-      ./mvnw
       ./mvnw -Pcapsule clean package -Dmaven.test.skip=true
     install:
-      mv ktlint/target/ktlint-0.0.0-SNAPSHOT-shaded.jar $SNAPCRAFT_PART_INSTALL
+      mv ktlint/target/ktlint $SNAPCRAFT_PART_INSTALL


### PR DESCRIPTION
This package will let you publish the latest ktlint in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.