### PR TITLE
snap: move java to an arch independent dir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ apps:
     command: ktlint
     plugs: [home]
     environment:
-      PATH: $PATH:$SNAP/usr/lib/jvm/java-8-openjdk-amd64/bin
+      PATH: $PATH:$SNAP/usr/lib/jvm/java-8-openjdk/bin
 
 parts:
   ktlint:
@@ -23,3 +23,5 @@ parts:
       ./mvnw -Pcapsule clean package -Dmaven.test.skip=true
     install:
       mv ktlint/target/ktlint $SNAPCRAFT_PART_INSTALL
+    organize:
+      usr/lib/jvm/java-8-openjdk-*: usr/lib/jvm/java-8-openjdk


### PR DESCRIPTION
Remove the hard-coded arch path to find the java bin.