### PR TITLE
Improve line length calculation in ClassAndFunctionHeaderFormatRule

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
-    private val newLineRegex by lazy { System.lineSeparator().toRegex() }
+    private val newLineRegex by lazy { "\n".toRegex() }
     private var indentConfig = IndentationConfig(-1, -1, true)
     private var lineLengthConfig = MaxLineLengthConfig(-1)
     override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRule.kt
@@ -9,13 +9,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.CompositeElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeUtil
-import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtClassBody
-import org.jetbrains.kotlin.psi.KtExpressionImpl
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
 class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
@@ -101,33 +95,26 @@ class ClassAndFunctionHeaderFormatRule : Rule(RULE_ID) {
             (parentParameterList.textRange.substring(parentFile.text).contains("\n") ||
                 //entire class definition exceed max line length
                 (lineLengthConfig.isEnabled() &&
-                    headerBodyLength(parentParameterList, parentFile) > lineLengthConfig.lineLength))
+                    calculateLineLength(parentParameterList, parentFile) > lineLengthConfig.lineLength))
     }
 
-    private fun headerBodyLength(node: ASTNode, parentFile: ASTNode?): Int {
-        val parentNode = PsiTreeUtil.findFirstParent(
-            node.psi,
-            { psiElement ->
-                psiElement is KtClass ||
-                    psiElement is KtNamedFunction ||
-                    psiElement is KtSecondaryConstructor
+    /**
+     * Calculates length of the line where [node] appears.
+     *
+     * Returns line length or zero, if line length cannot be calculated
+     */
+    private fun calculateLineLength(node: ASTNode, parentFile: ASTNode?): Int {
+        val res = newLineRegex.findAll(parentFile?.text ?: "").iterator()
+        var startIndex = 0
+        while (res.hasNext()) {
+            val match: MatchResult = res.next()
+            if (node.startOffset in startIndex..match.range.first) {
+                return match.range.first - startIndex
+            } else {
+                startIndex = match.range.first + match.value.length
             }
-        )
-        return if (parentNode != null && parentFile != null) {
-            val expressionOrBodyNode = PsiTreeUtil.findChildOfAnyType(parentNode, KtClassBody::class.java, KtExpressionImpl::class.java)
-            val bodyOffset = expressionOrBodyNode?.textOffset ?: parentNode.textOffset + parentNode.textLength
-            val headerWithoutBodyText = parentFile.text.substring(parentNode.textOffset, bodyOffset)
-            //TODO cover that with tests
-            //we also count first opening brace
-            val bracketSize = if (expressionOrBodyNode?.firstChild == KtTokens.LBRACE) 1 else 0
-            headerWithoutBodyText.length - countLineBreak(headerWithoutBodyText) + bracketSize
-        } else {
-            0
         }
-    }
-
-    private fun countLineBreak(text: String): Int {
-        return newLineRegex.findAll(text, 0).toList().size
+        return 0
     }
 
     companion object {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ClassAndFunctionHeaderFormatRuleTest.kt
@@ -3,21 +3,24 @@ package com.github.shyiko.ktlint.ruleset.standard
 import com.github.shyiko.ktlint.core.LintError
 import com.github.shyiko.ktlint.test.format
 import com.github.shyiko.ktlint.test.lint
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.Test
 
 class ClassAndFunctionHeaderFormatRuleTest {
     private val errorMessageMissedNewLineForParameter = "Parameter should be on separate line with indentation"
     private val errorMessageMissedNewLineForParenthesis = "Parenthesis should be on new line"
     private val expectedRuleId = "class-and-function-header-format"
-    private val configUserData = mapOf("indent_size" to "4", "continuation_indent_size" to "6")
+    private val configUserData = mapOf(
+        "indent_size" to "4",
+        "continuation_indent_size" to "6",
+        "max_line_length" to "100")
     private fun errorMessageWhenWrongIndent(actualIndent: Int, expectedIndent: Int): String {
         return "Unexpected indentation for parameter $actualIndent (should be $expectedIndent)"
     }
 
     @Test
     fun testClassWithAbsentLineBreak() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(paramA: String, paramB: String,
                          paramC: String)
@@ -34,7 +37,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testFormatClassWithAbsentLineBreak() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+        assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class ClassA(paramA: String, paramB: String,
                          paramC: String)
@@ -53,7 +56,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testValidClassDefinitionWithMultipleLines() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(
                 paramA: String,
@@ -67,7 +70,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testValidClassDefinitionOnOneLine() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class ClassA(paramA: String, paramB: String, paramC: String)
             """.trimIndent(),
@@ -77,7 +80,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testErrorWhenFirstParameterIsNotOnNewLine() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             fun f(a: Any,
                   b: Any,
@@ -97,7 +100,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testFormatWhenFirstParameterIsNoOnNewLine() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+        assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             fun f(a: Any,
                   b: Any,
@@ -119,7 +122,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testIgnoreLambdaParameters() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             val fieldExample =
                   LongNameClass { paramA,
@@ -134,7 +137,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testFailWhenWrongIndentIsUsed() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class A {
                 fun f(
@@ -155,7 +158,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testRespectOuterIndent() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+        assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class A {
                 fun f(a: Any,
@@ -181,7 +184,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testRespectOuterIndentWhenCalculateParanthesisIndent() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+        assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class A {
                 fun f(a: Any,
@@ -208,7 +211,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testFailWhenHeaderIsTooLong() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().lint(
+        assertThat(ClassAndFunctionHeaderFormatRule().lint(
             """
             class WithLongClassHeader(parameter1: Int, parameter2: Int, parameter3: Int) {
               fun a() = ""
@@ -227,7 +230,7 @@ class ClassAndFunctionHeaderFormatRuleTest {
 
     @Test
     fun testFormatClassWithAllCases() {
-        Assertions.assertThat(ClassAndFunctionHeaderFormatRule().format(
+        assertThat(ClassAndFunctionHeaderFormatRule().format(
             """
             class WithLongClassHeader(parameter1: Int, parameter2: Int, parameter3: Int) {
                 constructor(parameter1: Int, parameter2: Int, parameter3: Int) {
@@ -284,6 +287,54 @@ class ClassAndFunctionHeaderFormatRuleTest {
                 }
             }
             """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testNoErrorWhenShorterThanMaxLengthSize() {
+        assertThat(
+            ClassAndFunctionHeaderFormatRule().lint(
+                """
+                class A {
+                    fun f(a: Any, b: Any) = ""
+                }
+                """.trimIndent(),
+                mapOf("max_line_length" to "31")
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testNoErrorWhenEqualToMaxLengthSize() {
+        assertThat(
+            ClassAndFunctionHeaderFormatRule().lint(
+                """
+                class A {
+                    fun f(a: Any, b: Any) = ""
+                }
+                """.trimIndent(),
+                mapOf("max_line_length" to "30")
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun testErrorWhenLongerThanMaxLengthSize() {
+        assertThat(
+            ClassAndFunctionHeaderFormatRule().lint(
+                """
+                class A {
+                    fun f(a: Any, b: Any) = ""
+                }
+                """.trimIndent(),
+                mapOf("max_line_length" to "29")
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(2, 11, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(2, 19, expectedRuleId, errorMessageMissedNewLineForParameter),
+                LintError(2, 25, expectedRuleId, errorMessageMissedNewLineForParenthesis)
+            )
         )
     }
 }


### PR DESCRIPTION
Fixes StringIndexOutOfBoundsException that can happen for class without body when max line length is specified.
Fixes line size calculation for secondary constructor and function.

How fix works: Just take entire line size, without any attempt to understand where is primary constructor, secondary constructor or class body. If line doesn't fit, than we should break parameter list definition into several lines.