### PR TITLE
fix wrapping for && and ||

### DIFF
--- a/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format-expected.kt.spec
@@ -10,6 +10,8 @@ fun main() {
         "bar"
     val s = true &&
         false
+    val s = b.equals(o.b) &&
+        g == o.g
     val d = 1 +
         -1
     val d = 1 +

--- a/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format.kt.spec
@@ -10,6 +10,8 @@ fun main() {
         + "bar"
     val s = true
         && false
+    val s = b.equals(o.b)
+        && g == o.g
     val d = 1 +
         -1
     val d = 1

--- a/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/lint.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/lint.kt.spec
@@ -10,6 +10,8 @@ fun main() {
         + "bar"
     val s = true
         && false
+    val s = b.equals(o.b)
+        && g == o.g
     val d = 1 +
         -1
     fn(
@@ -26,3 +28,4 @@ fun main() {
 // 7:18:Line must not end with "?."
 // 10:9:Line must not begin with "+"
 // 12:9:Line must not begin with "&&"
+// 14:9:Line must not begin with "&&"


### PR DESCRIPTION
I believe this fixes part of the problem described in #168 where certain characters will cause enforcement of the `Line must not being with "&&"` rule to fail.

I also did a bit of refactoring to try to make the code easier to read as I worked through figuring this out.

I'm not entirely sure if I've got the tokens separated properly between the "always" and "sometimes" groups.