### PR TITLE
Update ModifierOrderRule to include annotations as part of its checks

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRule.kt
@@ -2,7 +2,6 @@ package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.Rule
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
-import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
 import org.jetbrains.kotlin.com.intellij.psi.tree.TokenSet
 import org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.ACTUAL_KEYWORD
@@ -72,12 +71,8 @@ class ModifierOrderRule : Rule("modifier-order") {
                     sorted.map { it.text }.joinToString(" ")
                 }\")", true)
                 if (autoCorrect) {
-                    node.removeRange(node.firstChildNode, node.lastChildNode.treeNext)
-                    modifierArr.forEachIndexed { i, _ ->
-                        node.addChild(sorted[i], null)
-                        if (i != sorted.size - 1) {
-                            node.addChild(PsiWhiteSpaceImpl(" "), null)
-                        }
+                    modifierArr.forEachIndexed { i, n ->
+                        node.replaceChild(n, sorted[i].clone() as ASTNode)
                     }
                 }
             }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
@@ -27,8 +27,14 @@ class ModifierOrderRuleTest {
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
                 override @Annotation fun getSomething() = ""
                 override @Annotation suspend public @Woohoo(data = "woohoo") fun doSomething() = ""
-                @AnnotationAboveLine
-                fun returnsSomething() = ""
+                @A
+                @B(v = [
+                    "foo",
+                    "baz",
+                    "bar"
+                ])
+                @C
+                suspend public fun returnsSomething() = ""
 
                 companion object {
                    const internal val V = ""
@@ -46,7 +52,13 @@ class ModifierOrderRuleTest {
             LintError(11, 5, "modifier-order", "Incorrect modifier order (should be \"override tailrec\")"),
             LintError(13, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation override\")"),
             LintError(14, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation @Woohoo(data = \"woohoo\") public override suspend\")"),
-            LintError(19, 8, "modifier-order", "Incorrect modifier order (should be \"internal const\")")
+            LintError(15, 5, "modifier-order", """Incorrect modifier order (should be "@A @B(v = [
+                |        "foo",
+                |        "baz",
+                |        "bar"
+                |    ]) @C public suspend")
+                """.trimMargin()),
+            LintError(25, 8, "modifier-order", "Incorrect modifier order (should be \"internal const\")")
         ))
     }
 
@@ -68,8 +80,14 @@ class ModifierOrderRuleTest {
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
                 override @Annotation fun getSomething() = ""
                 suspend @Annotation override public @Woohoo(data = "woohoo") fun doSomething() = ""
-                @AnnotationAboveLine
-                fun returnsSomething() = ""
+                @A
+                @B(v = [
+                    "foo",
+                    "baz",
+                    "bar"
+                ])
+                @C
+                suspend public fun returnsSomething() = ""
 
                 companion object {
                    const internal val V = ""
@@ -92,8 +110,14 @@ class ModifierOrderRuleTest {
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
                 @Annotation override fun getSomething() = ""
                 @Annotation @Woohoo(data = "woohoo") public override suspend fun doSomething() = ""
-                @AnnotationAboveLine
-                fun returnsSomething() = ""
+                @A
+                @B(v = [
+                    "foo",
+                    "baz",
+                    "bar"
+                ])
+                @C
+                public suspend fun returnsSomething() = ""
 
                 companion object {
                    internal const val V = ""

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
@@ -13,7 +13,7 @@ class ModifierOrderRuleTest {
         // pretty much every line below should trip an error
         assertThat(ModifierOrderRule().lint(
             """
-            abstract open class A { // open is here for test purposes only, otherwise it's redundant
+            abstract @Deprecated open class A { // open is here for test purposes only, otherwise it's redundant
                 open protected val v = ""
                 open suspend internal fun f(v: Any): Any = ""
                 lateinit public var lv: String
@@ -25,6 +25,10 @@ class ModifierOrderRuleTest {
                 suspend override fun f(v: Any): Any = ""
                 tailrec override fun findFixPoint(x: Double): Double
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
+                override @Annotation fun getSomething() = ""
+                override @Annotation suspend public @Woohoo(data = "woohoo") fun doSomething() = ""
+                @AnnotationAboveLine
+                fun returnsSomething() = ""
 
                 companion object {
                    const internal val V = ""
@@ -32,7 +36,7 @@ class ModifierOrderRuleTest {
             }
             """.trimIndent()
         )).isEqualTo(listOf(
-            LintError(1, 1, "modifier-order", "Incorrect modifier order (should be \"open abstract\")"),
+            LintError(1, 1, "modifier-order", "Incorrect modifier order (should be \"@Deprecated open abstract\")"),
             LintError(2, 5, "modifier-order", "Incorrect modifier order (should be \"protected open\")"),
             LintError(3, 5, "modifier-order", "Incorrect modifier order (should be \"internal open suspend\")"),
             LintError(4, 5, "modifier-order", "Incorrect modifier order (should be \"public lateinit\")"),
@@ -40,7 +44,9 @@ class ModifierOrderRuleTest {
             LintError(9, 5, "modifier-order", "Incorrect modifier order (should be \"public override\")"),
             LintError(10, 5, "modifier-order", "Incorrect modifier order (should be \"override suspend\")"),
             LintError(11, 5, "modifier-order", "Incorrect modifier order (should be \"override tailrec\")"),
-            LintError(15, 8, "modifier-order", "Incorrect modifier order (should be \"internal const\")")
+            LintError(13, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation override\")"),
+            LintError(14, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation @Woohoo(data = \"woohoo\") public override suspend\")"),
+            LintError(19, 8, "modifier-order", "Incorrect modifier order (should be \"internal const\")")
         ))
     }
 
@@ -48,7 +54,7 @@ class ModifierOrderRuleTest {
     fun testFormat() {
         assertThat(ModifierOrderRule().format(
             """
-            abstract open class A { // open is here for test purposes only, otherwise it's redundant
+            abstract @Deprecated open class A { // open is here for test purposes only, otherwise it's redundant
                 open protected val v = ""
                 open suspend internal fun f(v: Any): Any = ""
                 lateinit public var lv: String
@@ -60,6 +66,10 @@ class ModifierOrderRuleTest {
                 suspend override fun f(v: Any): Any = ""
                 tailrec override fun findFixPoint(x: Double): Double
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
+                override @Annotation fun getSomething() = ""
+                suspend @Annotation override public @Woohoo(data = "woohoo") fun doSomething() = ""
+                @AnnotationAboveLine
+                fun returnsSomething() = ""
 
                 companion object {
                    const internal val V = ""
@@ -68,7 +78,7 @@ class ModifierOrderRuleTest {
             """
         )).isEqualTo(
             """
-            open abstract class A { // open is here for test purposes only, otherwise it's redundant
+            @Deprecated open abstract class A { // open is here for test purposes only, otherwise it's redundant
                 protected open val v = ""
                 internal open suspend fun f(v: Any): Any = ""
                 public lateinit var lv: String
@@ -80,6 +90,10 @@ class ModifierOrderRuleTest {
                 override suspend fun f(v: Any): Any = ""
                 override tailrec fun findFixPoint(x: Double): Double
                     = if (x == Math.cos(x)) x else findFixPoint(Math.cos(x))
+                @Annotation override fun getSomething() = ""
+                @Annotation @Woohoo(data = "woohoo") public override suspend fun doSomething() = ""
+                @AnnotationAboveLine
+                fun returnsSomething() = ""
 
                 companion object {
                    internal const val V = ""

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ModifierOrderRuleTest.kt
@@ -42,7 +42,7 @@ class ModifierOrderRuleTest {
             }
             """.trimIndent()
         )).isEqualTo(listOf(
-            LintError(1, 1, "modifier-order", "Incorrect modifier order (should be \"@Deprecated open abstract\")"),
+            LintError(1, 1, "modifier-order", "Incorrect modifier order (should be \"@Annotation... open abstract\")"),
             LintError(2, 5, "modifier-order", "Incorrect modifier order (should be \"protected open\")"),
             LintError(3, 5, "modifier-order", "Incorrect modifier order (should be \"internal open suspend\")"),
             LintError(4, 5, "modifier-order", "Incorrect modifier order (should be \"public lateinit\")"),
@@ -50,14 +50,9 @@ class ModifierOrderRuleTest {
             LintError(9, 5, "modifier-order", "Incorrect modifier order (should be \"public override\")"),
             LintError(10, 5, "modifier-order", "Incorrect modifier order (should be \"override suspend\")"),
             LintError(11, 5, "modifier-order", "Incorrect modifier order (should be \"override tailrec\")"),
-            LintError(13, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation override\")"),
-            LintError(14, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation @Woohoo(data = \"woohoo\") public override suspend\")"),
-            LintError(15, 5, "modifier-order", """Incorrect modifier order (should be "@A @B(v = [
-                |        "foo",
-                |        "baz",
-                |        "bar"
-                |    ]) @C public suspend")
-                """.trimMargin()),
+            LintError(13, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation... override\")"),
+            LintError(14, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation... public override suspend\")"),
+            LintError(15, 5, "modifier-order", "Incorrect modifier order (should be \"@Annotation... public suspend\")"),
             LintError(25, 8, "modifier-order", "Incorrect modifier order (should be \"internal const\")")
         ))
     }


### PR DESCRIPTION
Annotations should precede all modifiers according to: https://kotlinlang.org/docs/reference/coding-conventions.html#modifiers

(It might make sense in the future to forbid having multiple annotations on the same line as the declaration per the link above. Not sure if that should be a new rule or not though; at the very least this should be an improvement over the existing check)

Had quite a bit of difficulty implementing the auto-format since annotation entries are a different type than all the other modifiers. I'm open to feedback on how to clean it up. :)