### PR TITLE
Fix syntax of main method in AST section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,10 +303,10 @@ A complete sample project (with tests and build files) is included in this repo 
 While writing/debugging [Rule](ktlint-core/src/main/kotlin/com/github/shyiko/ktlint/core/Rule.kt)s it's often helpful to have an AST
 printed out to see the structure rules have to work with. ktlint >= 0.15.0 has `--print-ast` flag specifically for this purpose
 (usage: `ktlint --color --print-ast <file>`).  
-An example of the output it shown below. 
+An example of the output is shown below. 
 
 ```sh
-$ printf "fun main {}" | ktlint --color --print-ast --stdin
+$ printf "fun main() {}" | ktlint --color --print-ast --stdin
 
 1: ~.psi.KtFile (~.psi.stubs.elements.KtFileElementType.kotlin.FILE)
 1:   ~.psi.KtPackageDirective (~.psi.stubs.elements.KtPlaceHolderStubElementType.PACKAGE_DIRECTIVE) ""


### PR DESCRIPTION
This took me longer than I'm willing to admit to realize the mistake when trying to run this example locally. :/