### PR TITLE
Handle comments better when moving operators to the end of a line.

### DIFF
--- a/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format-expected.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format-expected.kt.spec
@@ -47,5 +47,10 @@ fun main() {
     var x =
         -2 >
         (2 + 2)
+    var y = false && // comment
+        false
+    y = false &&
+        // comment
+        false
     -3
 }

--- a/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format.kt.spec
+++ b/ktlint-ruleset-standard/src/test/resources/spec/chain-wrapping/format.kt.spec
@@ -47,5 +47,10 @@ fun main() {
     var x =
         -2 >
         (2 + 2)
+    var y = false // comment
+        && false
+    y = false
+        // comment
+        && false
     -3
 }


### PR DESCRIPTION
Closes #192 

This is probably a poor implementation of a fix, but it seems to work. I'd appreciate pointers in how to make it better.