### PR TITLE
Fix ParameterListWrappingRule to correctly identify misplaced left parens

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRule.kt
@@ -47,12 +47,21 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
             if (putParametersOnSeparateLines || maxLineLengthExceeded) {
                 // aiming for
                 // ... LPAR
-                // <LPAR line indent + indentSize> VALUE_PARAMETER...
-                // <LPAR line indent> RPAR
+                // <line indent + indentSize> VALUE_PARAMETER...
+                // <line indent> RPAR
                 val indent = "\n" + node.psi.lineIndent()
                 val paramIndent = indent + " ".repeat(indentSize) // single indent as recommended by Jetbrains/Google
                 nextChild@ for (child in node.children()) {
                     when (child.elementType) {
+                        KtTokens.LPAR -> {
+                            val prevLeaf = child.psi.prevLeaf()!!
+                            if (prevLeaf.elementType == KtTokens.WHITE_SPACE && prevLeaf.textContains('\n')) {
+                                emit(child.startOffset, errorMessage(child), true)
+                                if (autoCorrect) {
+                                    prevLeaf.delete()
+                                }
+                            }
+                        }
                         KtStubElementTypes.VALUE_PARAMETER,
                         KtTokens.RPAR -> {
                             var paramInnerIndentAdjustment = 0
@@ -128,6 +137,7 @@ class ParameterListWrappingRule : Rule("parameter-list-wrapping") {
 
     private fun errorMessage(node: ASTNode) =
         when (node.elementType) {
+            KtTokens.LPAR -> """Unnecessary newline before "(""""
             KtStubElementTypes.VALUE_PARAMETER ->
                 "Parameter should be on a separate line (unless all parameters can fit a single line)"
             KtTokens.RPAR -> """Missing newline before ")""""

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/ParameterListWrappingRuleTest.kt
@@ -391,4 +391,92 @@ class ParameterListWrappingRuleTest {
             LintError(6, 4, "parameter-list-wrapping", "Unexpected indentation (expected 4, actual 3)")
         ))
     }
+
+    @Test
+    fun testLintClassDanglingLeftParen() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+            """
+            class ClassA
+            (
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(2, 1, "parameter-list-wrapping", """Unnecessary newline before "("""")
+            )
+        )
+    }
+
+    @Test
+    fun testLintFunctionDanglingLeftParen() {
+        assertThat(
+            ParameterListWrappingRule().lint(
+            """
+            fun doSomething
+            (
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+            )
+        ).isEqualTo(
+            listOf(
+                LintError(2, 1, "parameter-list-wrapping", """Unnecessary newline before "("""")
+            )
+        )
+    }
+
+    @Test
+    fun testFormatClassDanglingLeftParen() {
+        assertThat(
+            ParameterListWrappingRule().format(
+            """
+            class ClassA constructor
+            (
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            class ClassA constructor(
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testFormatFunctionDanglingLeftParen() {
+        assertThat(
+            ParameterListWrappingRule().format(
+            """
+            fun doSomething
+            (
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+            )
+        ).isEqualTo(
+            """
+            fun doSomething(
+                paramA: String,
+                paramB: String,
+                paramC: String
+            )
+            """.trimIndent()
+        )
+    }
 }


### PR DESCRIPTION
Noticed a dev in my team writing code like this that passed Ktlint, so adding a quick fix here for it.

Sidenote: It feels like identifying dangling left parens should be part of a broader rule. Right now, the following code is valid according to Ktlint (athough I think it'd be pretty rare to see a dev actually write something like this, Ktlint should still probably catch it):

```
if
(someCondition) {
    doSomething()
}
```

However, given that this error is likely a lot more common in class/function headers I just added the fix there for now (also because we're handling right paren formatting in it). Let me know what you think though!