### PR TITLE
Add ability to specify editorconfig path

### DIFF
--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -187,6 +187,14 @@ object Main {
     @Option(names = arrayOf("-y"), hidden = true)
     private var forceApply: Boolean = false
 
+    @Option(names = arrayOf("--editorconfig-path"), description = arrayOf("Specify folder path of .editorconfig"))
+    private var editorConfigDirParam: String? = null
+    private val editorConfigDir: String
+        get() {
+            val filePath = if (editorConfigDirParam == null) File(".") else File(editorConfigDirParam)
+            return filePath.canonicalPath
+        }
+
     @Parameters(hidden = true)
     private var patterns = ArrayList<String>()
 
@@ -262,7 +270,7 @@ object Main {
         val reporter = loadReporter(dependencyResolver)
         // load .editorconfig
         val userData = (
-            EditorConfig.of(workDir)
+            EditorConfig.of(editorConfigDir)
                 ?.also { editorConfig ->
                     if (debug) {
                         System.err.println("[DEBUG] Discovered .editorconfig (${

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/EditorConfigFinder.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/internal/EditorConfigFinder.kt
@@ -1,0 +1,52 @@
+package com.github.shyiko.ktlint.internal
+
+import java.io.File
+
+class EditorConfigFinder(private val workDir: String, private val debug: Boolean) {
+
+    private val editorConfigs = mutableMapOf<String, EditorConfig?>()
+
+    init {
+        editorConfigs[workDir] = EditorConfig.of(workDir)
+    }
+
+    @Synchronized
+    fun getEditorConfig(file: File): EditorConfig? = editorConfigs.getOrPut(file.key(), {
+        findParentEditorConfig(file)
+    })
+
+    @Synchronized
+    fun getEditorConfig(filePath: String): EditorConfig? = getEditorConfig(File(filePath))
+
+    private fun findParentEditorConfig(file: File): EditorConfig? {
+        var currentFile: File = if (file.isDirectory) file else file.parentFile
+        val pathsWithMissingEditorConfig = mutableListOf<String>()
+
+        while (currentFile.canonicalPath != workDir) {
+            val currentPath = currentFile.canonicalPath
+            val editorConfigFile = File("$currentPath/.editorconfig")
+            if (editorConfigFile.exists() && editorConfigFile.isFile) {
+                if (debug) {
+                    System.err.println("[DEBUG] Found .editorconfig for ${file.name} in ${editorConfigFile.canonicalPath}")
+                }
+
+                return EditorConfig.of(currentPath)?.also {
+                    pathsWithMissingEditorConfig.forEach { path ->
+                        editorConfigs[path] = it
+                    }
+                }
+            }
+
+            pathsWithMissingEditorConfig.add(currentPath)
+            currentFile = currentFile.parentFile
+        }
+
+        return editorConfigs[workDir]?.also {
+            pathsWithMissingEditorConfig.forEach { path ->
+                editorConfigs[path] = it
+            }
+        }
+    }
+
+    private fun File.key() = this.parent
+}


### PR DESCRIPTION
* Adds the ability to user to specify the `.editorconfig` path.

### The problem:

I setup ktlint in my [project](https://github.com/charbgr/cliffhanger) and then I installed the [pre-commit](https://github.com/shyiko/ktlint/blob/master/ktlint/src/main/resources/ktlint-git-pre-commit-hook.sh) hook. "Real" code is under `cliffhanger/` folder and the `.editorconfig.` is placed under that folder. 
The issue is that pre-commit hook is being installed in the parent git directory (where not "Real" code exists) and the `.editorconfig` is placed in a different folder, resulting to wrong lint warnings.

With this fix I can modify my pre-commit hook and set editoconfig path by
```
$ git diff --name-only --cached --relative | grep '\.kt[s"]\?$' | xargs ktlint --relative . --editorconfig-path="cliffhanger/"
```

Let me know what you think and looking forward to your constructive feedback!