### PR TITLE
Indent rule: auto correction and curly braces

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRule.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.com.intellij.lang.FileASTNode
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.psi.KtParameterList
 import org.jetbrains.kotlin.psi.KtTypeConstraintList
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
@@ -38,8 +39,11 @@ class IndentationRule : Rule("indent") {
                             emit(
                                 offset,
                                 "Unexpected indentation (${indent.length}) (it should be ${previousIndentSize + indentSize})",
-                                false
+                                true
                             )
+                            if (autoCorrect) {
+                                replaceWithExpectedIndent(node, previousIndentSize + indentSize)
+                            }
                         }
                     }
                     offset += indent.length + 1
@@ -52,6 +56,11 @@ class IndentationRule : Rule("indent") {
         a > b -> gcd(a - b, b)
         a < b -> gcd(a, b - a)
         else -> a
+    }
+
+    private fun replaceWithExpectedIndent(node: ASTNode, expectedIndentSize: Int) {
+        val correctedIndent = "\n" + " ".repeat(expectedIndentSize)
+        (node as LeafPsiElement).rawReplaceWithText(correctedIndent)
     }
 
     // todo: calculating indent based on the previous line value is wrong (see IndentationRule.testLint)

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/NoSemicolonsRule.kt
@@ -16,12 +16,12 @@ class NoSemicolonsRule : Rule("no-semi") {
         emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
     ) {
         if (node is LeafPsiElement && node.textMatches(";") && !node.isPartOfString() &&
-                !node.isPartOf(KtEnumEntry::class)) {
+            !node.isPartOf(KtEnumEntry::class)) {
             val nextLeaf = PsiTreeUtil.nextLeaf(node, true)
             if (nextLeaf == null /* eof */ ||
                 (nextLeaf is PsiWhiteSpace && (nextLeaf.text.contains("\n") ||
                     PsiTreeUtil.nextLeaf(nextLeaf, true) == null /* \s+ and then eof */))
-                ) {
+            ) {
                 emit(node.startOffset, "Unnecessary semicolon", true)
                 if (autoCorrect) {
                     node.treeParent.removeChild(node)

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -309,4 +309,94 @@ class IndentationRuleTest {
             """.trimIndent()
         )).isEmpty()
     }
+
+    @Test
+    fun testFormatCurlyBraceInWhereBlock() {
+        assertThat(IndentationRule().format(
+            """
+            class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                val adapter1: A1
+            ) : RecyclerView.Adapter<C>()
+                where A1 : Type1,
+                      A2 : Type2 {
+             }
+            """.trimIndent()
+        )).isEqualTo(
+            """
+            class BiAdapter<C : RecyclerView.ViewHolder, V1 : C, V2 : C, out A1, out A2>(
+                val adapter1: A1
+            ) : RecyclerView.Adapter<C>()
+                where A1 : Type1,
+                      A2 : Type2 {
+            }
+                """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testCurlyBrace() {
+        assertThat(IndentationRule().lint(
+            """
+            class ReaderFacade {
+                fun run() {
+                 }
+            }
+              """.trimIndent()
+        )).isEqualTo(
+            listOf(
+                LintError(3, 1, "indent", "Unexpected indentation (5) (it should be 4)")
+            )
+        )
+    }
+
+    @Test
+    fun testCurlyBraceFormat() {
+        assertThat(IndentationRule().format(
+            """
+                class ReaderFacade {
+                    fun run() {
+                     }
+                }
+              """.trimIndent()
+        )).isEqualTo(
+            """
+                class ReaderFacade {
+                    fun run() {
+                    }
+                }
+                """.trimIndent()
+        )
+    }
+
+    @Test
+    fun testCurlyBraceInNestedBlockWithComment() {
+        assertThat(IndentationRule().lint(
+            """
+            object KtLint {
+                // comment
+                class LoggerFactory {
+                }
+            }
+              """.trimIndent()
+        )).isEmpty()
+    }
+
+    @Test
+    fun testCurlyBraceWithCompanionObjectFormat() {
+        assertThat(IndentationRule().format(
+            """
+            class Foo {
+              // asdf
+                companion object {
+                }
+            }
+              """.trimIndent()
+        )).isEqualTo("""
+            class Foo {
+                // asdf
+                companion object {
+                }
+            }
+        """.trimIndent())
+    }
 }

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/IndentationRuleTest.kt
@@ -1,6 +1,7 @@
 package com.github.shyiko.ktlint.ruleset.standard
 
 import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.test.format
 import com.github.shyiko.ktlint.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.annotations.Test
@@ -10,6 +11,39 @@ class IndentationRuleTest {
     @Test
     fun testLint() {
         assertThat(IndentationRule().lint(
+            """
+            /**
+             * _
+             */
+            fun main() {
+                val a = 0
+                // this is not detected because actual indent 8 % 4 = 0
+                    val b = 0
+                if (a == 0) {
+                    println(a)
+                }
+                val b = builder().setX().setY()
+                    .build()
+               val c = builder("long_string" +
+                     "")
+            }
+
+            class A {
+                var x: String
+                    get() = ""
+                    set(v: String) { x = v }
+            }
+            """.trimIndent()
+        )).isEqualTo(listOf(
+            LintError(13, 1, "indent", "Unexpected indentation (3) (it should be 4)"),
+            // fixme: expected indent should not depend on the "previous" line value
+            LintError(14, 1, "indent", "Unexpected indentation (9) (it should be 7)")
+        ))
+    }
+
+    @Test
+    fun testLintFormat() {
+        assertThat(IndentationRule().format(
             """
             /**
              * _
@@ -32,11 +66,28 @@ class IndentationRuleTest {
                     set(v: String) { x = v }
             }
             """.trimIndent()
-        )).isEqualTo(listOf(
-            LintError(12, 1, "indent", "Unexpected indentation (3) (it should be 4)"),
-            // fixme: expected indent should not depend on the "previous" line value
-            LintError(13, 1, "indent", "Unexpected indentation (9) (it should be 7)")
-        ))
+        )).isEqualTo("""
+            /**
+             * _
+             */
+            fun main() {
+                val a = 0
+                    val b = 0
+                if (a == 0) {
+                    println(a)
+                }
+                val b = builder().setX().setY()
+                    .build()
+                val c = builder("long_string" +
+                    "")
+            }
+
+            class A {
+                var x: String
+                    get() = ""
+                    set(v: String) { x = v }
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -52,6 +103,25 @@ class IndentationRuleTest {
         )).isEqualTo(listOf(
             LintError(3, 1, "indent", "Unexpected indentation (4) (it should be 3)")
         ))
+    }
+
+    @Test
+    fun testLintCustomIndentSizeFormat() {
+        assertThat(IndentationRule().format(
+            """
+            fun main() {
+               val v = ""
+                println(v)
+            }
+            """.trimIndent(),
+            mapOf("indent_size" to "3")
+        )).isEqualTo("""
+            fun main() {
+               val v = ""
+               println(v)
+            }
+        """.trimIndent()
+        )
     }
 
     @Test
@@ -136,15 +206,39 @@ class IndentationRuleTest {
         assertThat(IndentationRule().lint(
             """
             fun main() {
-                fn(a,
+                fn(
+                   a,
                    b,
                    c)
             }
             """.trimIndent()
         )).isEqualTo(listOf(
             LintError(3, 1, "indent", "Unexpected indentation (7) (it should be 8)"),
-            LintError(4, 1, "indent", "Unexpected indentation (7) (it should be 8)")
+            LintError(4, 1, "indent", "Unexpected indentation (7) (it should be 8)"),
+            LintError(5, 1, "indent", "Unexpected indentation (7) (it should be 8)")
         ))
+    }
+
+    // https://kotlinlang.org/docs/reference/coding-conventions.html#method-call-formatting
+    @Test
+    fun testLintMultilineFunctionCallFormat() {
+        assertThat(IndentationRule().format(
+            """
+            fun main() {
+                fn(
+                   a,
+                   b,
+                   c)
+            }
+            """.trimIndent()
+        )).isEqualTo("""
+            fun main() {
+                fn(
+                    a,
+                    b,
+                    c)
+            }
+        """.trimIndent())
     }
 
     @Test
@@ -167,6 +261,38 @@ class IndentationRuleTest {
         )).isEqualTo(listOf(
             LintError(7, 1, "indent", "Unexpected indentation (1) (it should be 8)")
         ))
+    }
+
+    @Test
+    fun testLintCommentsAreIgnoredFormat() {
+        assertThat(IndentationRule().format(
+            """
+            fun funA(argA: String) =
+                // comment
+            // comment
+                call(argA)
+            fun main() {
+                addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+             // comment
+                    override fun onLayoutChange(
+                    )
+                })
+            }
+            """.trimIndent(),
+            mapOf("indent_size" to "4")
+        )).isEqualTo("""
+            fun funA(argA: String) =
+                // comment
+            // comment
+                call(argA)
+            fun main() {
+                addOnLayoutChangeListener(object : View.OnLayoutChangeListener {
+                    // comment
+                    override fun onLayoutChange(
+                    )
+                })
+            }
+        """.trimIndent())
     }
 
     @Test(description = "https://github.com/shyiko/ktlint/issues/180")

--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -492,8 +492,7 @@ object Main {
                 val scanner = Scanner(System.`in`)
                 val res = generateSequence {
                         try { scanner.next() } catch (e: NoSuchElementException) { null }
-                    }
-                    .filter { line -> !line.trim().isEmpty() }
+                }.filter { line -> !line.trim().isEmpty() }
                     .first()
                 if (!"y".equals(res, ignoreCase = true)) {
                     System.err.println("(update canceled)")


### PR DESCRIPTION
This PR contains two changes: Auto correction and support for curly braces `}`.
Please review it commit by commit. Or let me know, if you prefer two separate PRs instead.

**Auto correction** ([jump to commit](https://github.com/shyiko/ktlint/commit/9bdec7eef13422c335245c6c2aa76310104443b7)]
Bring back auto correction support, that was initially introduced in #137 . 
How it works: Just adjust indent according to expected indent. Since rule is executed line by line, we can be sure that previous indent is already correct.

**Support for curly brances** ([jump to commit](https://github.com/shyiko/ktlint/commit/e5a018c74fd57dbb28d925dfb719750518d13b84))
Fixes #141 
How it works: We start distinguish between "regular indent" and "absence of indent".  Knowledge which indent to use is encapsulated in `expectedIndentForNode`. Also there are cases, when we should immediately "jump" to next parent during "previous indent" calculation. That knowledge is encapsulated in `getParentNodeForIndent`.

**Refactoring** ([jump to commit](https://github.com/shyiko/ktlint/commit/38ac35e1352e79806f3d55e06df892314948947f))
Group all cases when we skip calculation in one place. Add comments with a reason, why we are skipping them.