### PR TITLE
Use permanent link to file as FilenameRule showcase reference

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/FilenameRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/FilenameRule.kt
@@ -49,7 +49,7 @@ class FilenameRule : Rule("filename"), Rule.Modifier.RestrictToRoot {
                 type = id?.psi?.getPrevSiblingIgnoringWhitespaceAndComments(false)?.text
                 className = id?.text
             } else if (!ignoreSet.contains(el.elementType)) {
-                // https://github.com/android/android-ktx/blob/master/src/main/java/androidx/core/graphics/Path.kt case
+                // https://github.com/android/android-ktx/blob/51005889235123f41492eaaecde3c623473dfe95/src/main/java/androidx/core/graphics/Path.kt case
                 return
             }
         }


### PR DESCRIPTION
Changed the link to a rule showcase to point to a spicific commit, rather than to master, because the version of a file at the head of branch can change as new commits are made and the file contents might not be the same when someone looks at it later.
