### PR TITLE
Fix escape characters in the generated json.

### DIFF
--- a/ktlint-reporter-json/src/main/kotlin/com/github/shyiko/ktlint/reporter/json/JsonReporter.kt
+++ b/ktlint-reporter-json/src/main/kotlin/com/github/shyiko/ktlint/reporter/json/JsonReporter.kt
@@ -22,7 +22,7 @@ class JsonReporter(val out: PrintStream) : Reporter {
         for ((index, entry) in acc.entries.sortedBy { it.key }.withIndex()) {
             val (file, errList) = entry
             out.println("""	{""")
-            out.println("""		"file": "${file.escapeJsonValue()}",""")
+            out.println("""		"file": "${file.escapeFileName()}",""")
             out.println("""		"errors": [""")
             val errIndexLast = errList.size - 1
             for ((errIndex, err) in errList.withIndex()) {
@@ -41,4 +41,6 @@ class JsonReporter(val out: PrintStream) : Reporter {
     }
 
     private fun String.escapeJsonValue() = this.replace("\"", "\\\"")
+
+    private fun String.escapeFileName() = this.replace("""\""", """\\""")
 }

--- a/ktlint-reporter-json/src/test/kotlin/com/github/shyiko/ktlint/reporter/json/JsonReporterTest.kt
+++ b/ktlint-reporter-json/src/test/kotlin/com/github/shyiko/ktlint/reporter/json/JsonReporterTest.kt
@@ -60,4 +60,32 @@ class JsonReporterTest {
 """.trimStart().replace("\n", System.lineSeparator())
         )
     }
+
+    @Test
+    fun testProperEscaping() {
+        val out = ByteArrayOutputStream()
+        val reporter = JsonReporter(PrintStream(out, true))
+        reporter.onLintError("src\\main\\all\\corrected.kt", LintError(4, 7, "rule-7", "Did it pass?"), false)
+        reporter.afterAll()
+
+        val result = String(out.toByteArray())
+        val shouldBe =
+            """
+[
+	{
+		"file": "src\\main\\all\\corrected.kt",
+		"errors": [
+			{
+				"line": 4,
+				"column": 7,
+				"message": "Did it pass?",
+				"rule": "rule-7"
+			}
+		]
+	}
+]
+""".trimStart().replace("\n", System.lineSeparator()
+            )
+        Assertions.assertThat(result).isEqualTo(shouldBe)
+    }
 }


### PR DESCRIPTION
Fixes #256 

I've ensured that the generated json regarding the LinterError is correctly escaped according to the json specification. I've also included a unit test to verify this new behaviour.