### PR TITLE
Issue#238 Check directory structure

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/DirectoryStructureRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/DirectoryStructureRule.kt
@@ -8,11 +8,10 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import java.io.File
 
 /**
- * @see [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html#naming-rules)
- * @see [Android Style Guide](https://android.github.io/kotlin-guides/style.html#package-names)
+ * @see [Kotlin Style Guide](https://kotlinlang.org/docs/reference/coding-conventions.html#directory-structure)
  * @author yokotaso <yokotaso.t@gmail.com>
  */
-class PackageNameRule : Rule("package-name") {
+class DirectoryStructureRule : Rule("directory-structure") {
 
     override fun visit(
         node: ASTNode,
@@ -28,10 +27,6 @@ class PackageNameRule : Rule("package-name") {
             if (!filePath.substringBeforeLast(File.separatorChar)
                     .endsWith(File.separatorChar + qualifiedName.replace('.', File.separatorChar))) {
                 emit(node.startOffset, "Package directive doesn't match file location", false)
-            }
-            if (qualifiedName.contains('_')) {
-                emit(node.startOffset, "Package name must not contain underscore", false)
-                // "package name must be in lowercase" is violated by too many to projects in the wild to forbid
             }
         }
     }

--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -10,7 +10,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         CommentSpacingRule(),
         FilenameRule(),
         FinalNewlineRule(),
-        PackageNameRule(),
+        DirectoryStructureRule(),
         // disabled until auto-correct is working properly
         // (e.g. try formatting "if (true)\n    return { _ ->\n        _\n}")
         // MultiLineIfElseRule(),

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/DirectoryStructureRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/DirectoryStructureRuleTest.kt
@@ -10,7 +10,7 @@ import java.nio.file.Paths
 /**
  * @author yokotaso <yokotaso.t@gmail.com>
  */
-class PackageNameRuleTest {
+class DirectoryStructureRuleTest {
 
     @Test
     fun testOK() {
@@ -27,16 +27,7 @@ class PackageNameRuleTest {
         assertNOK(
             "package hoge.fuga",
             "/hoge/moge/A.kt",
-            listOf(LintError(1, 1, "package-name", "Package directive doesn't match file location"))
-        )
-    }
-
-    @Test
-    fun testNOKUnderScore() {
-        assertNOK(
-            "package hoge.moge.hoge_moge",
-            "/hoge/moge/hoge_moge/A.kt",
-            listOf(LintError(1, 1, "package-name", "Package name must not contain underscore"))
+            listOf(LintError(1, 1, "directory-structure", "Package directive doesn't match file location"))
         )
     }
 
@@ -52,10 +43,10 @@ class PackageNameRuleTest {
         mapOf("file_path" to Paths.get(URI.create("file:///$fileName")).toString())
 
     private fun assertOK(ktScript: String, fileName: String) {
-        assertThat(PackageNameRule().lint(ktScript, fileName(fileName))).isEmpty()
+        assertThat(DirectoryStructureRule().lint(ktScript, fileName(fileName))).isEmpty()
     }
 
     private fun assertNOK(ktScript: String, fileName: String, lintErrors: List<LintError>) {
-        assertThat(PackageNameRule().lint(ktScript, fileName(fileName))).isEqualTo(lintErrors)
+        assertThat(DirectoryStructureRule().lint(ktScript, fileName(fileName))).isEqualTo(lintErrors)
     }
 }


### PR DESCRIPTION
There are rules about package name:
- https://kotlinlang.org/docs/reference/coding-conventions.html#naming-rules
- https://android.github.io/kotlin-guides/style.html#package-names

 if we will check it, Backword compatibility is missing. So, This rule check structure of directory.

See also:
* https://kotlinlang.org/docs/reference/coding-conventions.html#directory-structure
* https://github.com/shyiko/ktlint/pull/246#issuecomment-414248741