### PR TITLE
minor typo correction in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Features:
 - **No configuration.** Which means no decisions to make, nothing to argue about and no special files to manage.   
 While this might sound extreme, keep in mind that `ktlint` tries to capture (reflect) **official code style** from [kotlinlang.org](https://kotlinlang.org/docs/reference/coding-conventions.html) and [Android Kotlin Style Guide](https://android.github.io/kotlin-guides/style.html)
-(+ [we respect you .editorconfig](#editorconfig) and support additional [ruleset](#creating-a-ruleset)|s).
+(+ [we respect your .editorconfig](#editorconfig) and support additional [ruleset](#creating-a-ruleset)|s).
 - **Built-in formatter.** So that you wouldn't have to fix all style violations by hand.
 - **Customizable output.** `plain` (+ `plain?group_by_file`), `json` and `checkstyle` reporters are available out-of-the-box. 
 It's also [easy to create your own](#creating-a-reporter).


### PR DESCRIPTION
"We respect you .editorconfig ... " to "We respect your .editorconfig ..." 