### PR TITLE
Fixing issue with CommentSpacingRule which would insert a space into a comment that was all forward slashes

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/CommentSpacingRule.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/CommentSpacingRule.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 
 class CommentSpacingRule : Rule("comment-spacing") {
 
+    private val allForwardSlashesRegex = Regex("\\/+")
+
     override fun visit(
         node: ASTNode,
         autoCorrect: Boolean,
@@ -28,7 +30,8 @@ class CommentSpacingRule : Rule("comment-spacing") {
                 !text.startsWith("// ") &&
                 !text.startsWith("//noinspection") &&
                 !text.startsWith("//region") &&
-                !text.startsWith("//endregion")
+                !text.startsWith("//endregion") &&
+                !allForwardSlashesRegex.matches(text)
             ) {
                 emit(node.startOffset, "Missing space after //", true)
                 if (autoCorrect) {

--- a/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
+++ b/ktlint-ruleset-standard/src/test/kotlin/com/github/shyiko/ktlint/ruleset/standard/CommentSpacingRuleTest.kt
@@ -62,4 +62,15 @@ class CommentSpacingRuleTest {
             """.trimIndent()
         )
     }
+
+    @Test
+    fun testAllForwardSlashes() {
+        assertThat(CommentSpacingRule().lint(
+            """
+                //////////////////////
+                // function
+                //////////////////////
+            """.trimIndent()
+        )).isEmpty()
+    }
 }


### PR DESCRIPTION
In our code base, we have some block comments in the form of:

```
////////////////
// functionName
////////////////
```
Previously, ktlint would insert spaces, turning that block into:
```
// //////////////
// functionName
// //////////////
```

This PR fixes that.