### PR TITLE
Update README.md to remove extra spaces in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ max_line_length=off
 > Skip all the way to the "Integration" section if you don't plan to use `ktlint`'s command line interface.
 
 ```sh
-curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint &&
-  chmod a+x ktlint &&
-  sudo mv ktlint /usr/local/bin/
+curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/local/bin/
 ```
 
 ... or just download `ktlint` from the [releases](https://github.com/shyiko/ktlint/releases) page  (`ktlint.asc` contains PGP signature which you can verify with `curl -sS https://keybase.io/shyiko/pgp_keys.asc | gpg --import && gpg --verify ktlint.asc`).  


### PR DESCRIPTION
Made installation command a single line to avoid extra spaces.