### PR TITLE
Upgrade to Kotlin 1.3.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-  id "org.jetbrains.kotlin.jvm" version "1.3.10" apply false
+  id "org.jetbrains.kotlin.jvm" version "1.3.20" apply false
 }
 
 ext.libraries = [
-  "kotlin_stdlib": "org.jetbrains.kotlin:kotlin-stdlib:1.3.10",
-  "kotlin_compiler_embeddable": "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.10",
+  "kotlin_stdlib": "org.jetbrains.kotlin:kotlin-stdlib:1.3.20",
+  "kotlin_compiler_embeddable": "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.20",
   "klob": "com.github.shyiko.klob:klob:0.2.1",
   "aether_api": "org.eclipse.aether:aether-api:1.1.0",
   "aether_spi": "org.eclipse.aether:aether-spi:1.1.0",

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.10</kotlin.version>
-        <kotlin.compiler.languageVersion>1.1</kotlin.compiler.languageVersion>
-        <kotlin.compiler.apiVersion>1.1</kotlin.compiler.apiVersion>
+        <kotlin.version>1.3.20</kotlin.version>
+        <kotlin.compiler.languageVersion>1.3</kotlin.compiler.languageVersion>
+        <kotlin.compiler.apiVersion>1.3</kotlin.compiler.apiVersion>
         <klob.version>0.2.1</klob.version>
         <aether.version>1.1.0</aether.version>
         <aether.maven.provider.version>3.3.9</aether.maven.provider.version>


### PR DESCRIPTION
**Why**
Fixes runtime error caused by `LONG_STRING_TEMPLATE_ENTRY` changing from a `KtNodeType` to the more generic `IElementType`.