### PR TITLE
[SECURITY] Resolve dependenices over HTTPS instead of HTTP

### DIFF
--- a/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
+++ b/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
@@ -642,8 +642,8 @@ object Main {
                  */
                 System.err.println(
                     "[WARN]: Repository ${it.id} is using an insecure protocol (eg. http, ftp, ect...). " +
-                    "This leave you vulnerable to a Man In The Middle (MITM) attack." +
-                    "Attackers can use this to achieve Remote Code Execution (RCE) your system."
+                    "This leaves you vulnerable to a Man In The Middle (MITM) attack. " +
+                    "Attackers can use this to achieve Remote Code Execution (RCE) on your system."
                 )
             }
         }


### PR DESCRIPTION
Before this change, all the repositories that have been used to resolve rulesets have downloaded those rulesets over HTTP instead of HTTPS. This leaves the user wide open to system compromise via a Man In The Middle (MITM) attack. This isn't just theoretical; POC code exists already.

See:
- https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/
- https://github.com/mveytsman/dilettante

I will file for a CVE number after this is merged and a release has been published.

This vulnerability has a CVSS v3.0 Base Score of 8.1

https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H