### PR TITLE
Add missing rules to ruleset

### DIFF
--- a/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
+++ b/ktlint-ruleset-standard/src/main/kotlin/com/github/shyiko/ktlint/ruleset/standard/StandardRuleSetProvider.kt
@@ -6,6 +6,7 @@ import com.github.shyiko.ktlint.core.RuleSetProvider
 class StandardRuleSetProvider : RuleSetProvider {
 
     override fun get(): RuleSet = RuleSet("standard",
+        AnnotationRule(),
         ChainWrappingRule(),
         CommentSpacingRule(),
         FilenameRule(),
@@ -36,6 +37,7 @@ class StandardRuleSetProvider : RuleSetProvider {
         SpacingAroundColonRule(),
         SpacingAroundCommaRule(),
         SpacingAroundCurlyRule(),
+        SpacingAroundDotRule(),
         SpacingAroundKeywordRule(),
         SpacingAroundOperatorsRule(),
         SpacingAroundParensRule(),


### PR DESCRIPTION
I've just noticed that the latest release was missing the latest added rules in the standard ruleset. I've added them, but you'd probably need to release again, right?